### PR TITLE
Separate drupal:quick-start into its own Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,14 +125,28 @@
             "drush config:set --yes system.logging error_level verbose",
             "drush pm:enable --yes default_content"
         ],
+        "drupal:run-server": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php web/core/scripts/drupal quick-start"
+        ],
         "post-create-project-cmd": [
             "@drupal:install",
-            "Composer\\Config::disableProcessTimeout",
-            "test -n \"$CI\" || php -d max_execution_time=0 web/core/scripts/drupal quick-start"
+            "test -n \"$CI\" || @drupal:run-server"
         ]
     },
     "scripts-descriptions": {
         "drupal:install": "Installs Drupal CMS.",
-        "drupal:install-dev": "Installs Drupal CMS, with additional modules and configuration tweaks for development."
+        "drupal:install-dev": "Installs Drupal CMS, with additional modules and configuration tweaks for development.",
+        "drupal:run-server": "Runs Drupal CMS using the PHP webserver and opens it in the default browser."
+    },
+    "scripts-aliases": {
+        "drupal:install": [
+            "si",
+            "sin"
+        ],
+        "drupal:run-server": [
+            "rs",
+            "serve"
+        ]
     }
 }


### PR DESCRIPTION
@phenaproxima what would you think of breaking `drupal quick-start` into a separate Composer script so it can be easily run again at any time on an existing installation?

```
$ composer | grep drupal:quick-start
  drupal:quick-start   [qs] Installs Drupal CMS (if not already installed) and runs the PHP webserver.

$  starshot-project (feature/separate-quick-start-script $=) composer run
Script to run:
  [drupal:install         ] Installs Drupal CMS.
  [drupal:install-dev     ] Installs Drupal CMS, with additional modules and configuration tweaks for development.
  [drupal:quick-start     ] Installs Drupal CMS (if not already installed) and runs the PHP webserver.
  [post-create-project-cmd]

$ composer drupal:quick-start
> Composer\Config::disableProcessTimeout
> @php web/core/scripts/drupal quick-start
Drupal is already installed. If you want to reinstall, remove sites/default/files and sites/default/settings.php.
Drupal development server started: <http://127.0.0.1:8895>
This server is not meant for production use.
One time login url: <http://127.0.0.1:8895/user/reset/1/1714249736/9-16mTTWnfdExAJoaLGv--oHIlMllbrM3GaXKzN1XA8/login>
Press Ctrl-C to quit the Drupal development server.
```