### PR TITLE
Add a `drupal:rebuild` Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,11 @@
             "drush user:password editor editor",
             "drush user:unblock editor"
         ],
+        "drupal:rebuild": [
+            "sudo rm -rf vendor web composer.lock patches.lock.json | true",
+            "@composer install",
+            "@drupal:install"
+        ],
         "drupal:run-server": [
             "Composer\\Config::disableProcessTimeout",
             "@php -d max_execution_time=0 web/core/scripts/drupal quick-start"
@@ -139,6 +144,7 @@
     "scripts-descriptions": {
         "drupal:install": "Installs Starshot.",
         "drupal:install-dev": "Installs Starshot, with additional modules and configuration tweaks for development.",
+        "drupal:rebuild": "Rebuilds the codebase and reinstalls Starshot from scratch. Should only be used for internal development.",
         "drupal:run-server": "Runs Starshot using the PHP webserver and opens it in the default browser."
     },
     "scripts-aliases": {


### PR DESCRIPTION
What would you think of this, @phenaproxima? This completely resets the application by removing all Composer artifacts (`vendor/`, `web/`, and `composer.lock`), reinstalling them with `composer install`, and running the Starshot install scripts. It's particularly helpful after a `git pull`.