### PR TITLE
Add infrastructure for automated tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,4 +96,4 @@ jobs:
           php /var/www/vendor/bin/drush core:cron
           echo
 
-          curl http://localhost/ 2>/dev/null
+          ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     },
     "require-dev": {
         "drupal/core-dev": "^10.3",
-        "drupal/default_content": "^2.0@alpha"
+        "drupal/default_content": "^2.0@alpha",
+        "weitzman/drupal-test-traits": "^2.2"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copy the samples below into your own phpunit.xml file.-->
+
+<!-- Using this project's bootstrap file allows tests in `ExistingSite`,
+    `ExistingSiteSelenium2DriverTest`, and `ExistingSiteWebDriverTest`
+     to run alongside core's test types. -->
+
+<!-- If you use the default `bootstrap-fast.php` and get 'class not
+     found' errors while running tests, head over to
+     https://gitlab.com/weitzman/drupal-test-traits/-/blob/master/src/bootstrap-fast.php
+     for explanation on how to register those classes.
+-->
+<phpunit bootstrap="vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php">
+    <php>
+        <env name="DTT_BASE_URL" value="http://localhost"/>
+        <env name="DTT_API_URL" value="http://localhost:9222"/>
+        <!-- <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", { "chromeOptions" : { "w3c": false } }, "http://localhost:4444/wd/hub"]'/> -->
+        <env name="DTT_MINK_DRIVER_ARGS" value='["firefox", null, "http://localhost:4444/wd/hub"]'/>
+        <env name="DTT_API_OPTIONS" value='{"socketTimeout": 360, "domWaitTimeout": 3600000}' />
+        <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /tmp
+             Specify a temporary directory for storing debug images and html documents.
+             These artifacts get copied to /sites/simpletest/browser_output by BrowserTestBase. -->
+        <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+        <!-- To disable deprecation testing completely uncomment the next line. -->
+        <!--<env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>-->
+        <!-- Specify the default directory screenshots should be placed. -->
+        <!--<env name="DTT_SCREENSHOT_REPORT_DIRECTORY" value=""/>-->
+        <!-- Specify the default directory page captures should be placed.
+            When using the \Drupal\Tests\Listeners\HtmlOutputPrinter printerClass this will default to
+            /sites/simpletest/browser_output. If using another printer such as teamcity this must be defined.
+            -->
+        <!--<env name="DTT_HTML_OUTPUT_DIRECTORY" value=""/>-->
+    </php>
+
+    <testsuites>
+        <!--<testsuite name="unit">
+            <directory>./web/modules/custom/*/tests/src/Unit</directory>
+        </testsuite>-->
+        <!--<testsuite name="kernel">
+            <directory>./web/modules/custom/*/tests/src/Kernel</directory>
+        </testsuite>-->
+        <testsuite name="existing-site">
+            <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSite. -->
+            <directory>./tests/src/ExistingSite</directory>
+        </testsuite>
+        <testsuite name="existing-site-javascript">
+            <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSiteJavascript. -->
+            <directory>./tests/src/ExistingSiteJavascript</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\starshot\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * @group starshot
+ */
+class BasicExpectationsTest extends ExistingSiteBase {
+
+  /**
+   * Tests basic expectations of a successful Starshot install.
+   */
+  public function testBasicExpectations(): void {
+    $this->drupalGet('/');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+}

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -16,7 +16,10 @@ class BasicExpectationsTest extends ExistingSiteBase {
    */
   public function testBasicExpectations(): void {
     $this->drupalGet('/');
-    $this->assertSession()->statusCodeEquals(200);
+
+    $assert_session = $this->assertSession();
+    $assert_session->statusCodeEquals(200);
+    $assert_session->elementAttributeContains('css', 'meta[name="Generator"]', 'content', 'Drupal');
   }
 
 }


### PR DESCRIPTION
Let's get Drupal Test Traits working and running on CI. Right now, the only actual _test_ we need is one that just confirms the site is available and is in fact being served by Drupal.