### PR TITLE
Add test coverage of meta tags configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,4 +96,4 @@ jobs:
 
       - name: Test
         working-directory: /var/www
-        run: ./vendor/bin/phpunit
+        run: ./vendor/bin/phpunit --testdox

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -35,8 +35,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       ],
       'moderation_state' => 'published',
     ]);
-    $this->drupalGet($node->toUrl());
-    $this->assertSame(200, $this->getSession()->getStatusCode(), $this->buildUrl($node->toUrl(), ['absolute' => TRUE]));
+    $this->drupalGet('/node/' . $node->id());
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');
     $this->assertMetaTag('og:description', 'Not a random summary...');

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -22,7 +22,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
 
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
-    $assert_session->elementAttributeContains('css', 'meta[name="Generator"]', 'content', 'Drupal');
+    $this->assertMetaTag('Generator', 'Drupal', exact: FALSE);
 
     $random = $this->getRandomGenerator();
 
@@ -115,7 +115,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
     $this->assertMetaTag('og:type', 'Event');
   }
 
-  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta'): void {
+  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta', bool $exact = TRUE): void {
     $name_attribute = match ($tag_name) {
       'meta' => str_contains($name, ':') ? 'property' : 'name',
       'link' => 'rel',
@@ -128,7 +128,9 @@ class BasicExpectationsTest extends ExistingSiteBase {
         'link' => 'href',
       });
 
-    $this->assertSame($expected_value, $actual_value);
+    $exact
+      ? $this->assertSame($expected_value, $actual_value)
+      : $this->assertStringContainsString($expected_value, $actual_value);
   }
 
 }

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -22,7 +22,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
 
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
-    $this->assertMetaTag('Generator', 'Drupal', exact: FALSE);
+    $this->assertMetaTag('Generator', 'Drupal', exact_match: FALSE);
 
     $random = $this->getRandomGenerator();
 
@@ -36,6 +36,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
     $this->drupalGet('/node/' . $node->id());
+    $this->assertMetaTag('Generator', 'Drupal', exact_match: FALSE);
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');
     $this->assertMetaTag('og:description', 'Not a random summary...');
@@ -115,7 +116,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
     $this->assertMetaTag('og:type', 'Event');
   }
 
-  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta', bool $exact = TRUE): void {
+  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta', bool $exact_match = TRUE): void {
     $name_attribute = match ($tag_name) {
       'meta' => str_contains($name, ':') ? 'property' : 'name',
       'link' => 'rel',
@@ -127,10 +128,12 @@ class BasicExpectationsTest extends ExistingSiteBase {
         'meta' => 'content',
         'link' => 'href',
       });
-
-    $exact
-      ? $this->assertSame($expected_value, $actual_value)
-      : $this->assertStringContainsString($expected_value, $actual_value);
+    if ($exact_match) {
+      $this->assertSame($expected_value, $actual_value);
+    }
+    else {
+      $this->assertStringContainsString($expected_value, $actual_value);
+    }
   }
 
 }

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\starshot\ExistingSite;
 
-use Drupal\Core\File\FileUrlGeneratorInterface;
-use Drupal\file\Entity\File;
-use Drupal\media\Entity\Media;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
@@ -22,118 +19,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
 
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
-    $this->assertMetaTag('Generator', 'Drupal', exact_match: FALSE);
-
-    $random = $this->getRandomGenerator();
-
-    // If we create a page, all the expected meta tags should be there.
-    $node = $this->createNode([
-      'type' => 'page',
-      'body' => [
-        'summary' => 'Not a random summary...',
-        'value' => $random->paragraphs(1),
-      ],
-      'moderation_state' => 'published',
-    ]);
-    $this->drupalGet('/index.php?q=node/' . $node->id());
-    $this->assertSame(200, $this->getSession()->getStatusCode(), $this->getSession()->getPage()->getContent());
-    $assert_session->statusCodeEquals(200);
-    $this->assertMetaTag('description', 'Not a random summary...');
-    $this->assertMetaTag('og:description', 'Not a random summary...');
-    $this->assertMetaTag('og:title', $node->getTitle());
-    $this->assertMetaTag('og:type', 'Basic page');
-
-    // Blog posts and events expose their image URLs in their meta tags, so
-    // create an image media entity to test with.
-    $file_uri = uniqid('public://') . '.png';
-    $file_uri = $random->image($file_uri, '100x100', '200x200');
-    $this->assertFileExists($file_uri);
-    $file = File::create(['uri' => $file_uri]);
-    $file->save();
-    $this->markEntityForCleanup($file);
-    $file_url = $this->container->get(FileUrlGeneratorInterface::class)
-      ->generateAbsoluteString($file_uri);
-
-    $media = Media::create([
-      'name' => $random->word(16),
-      'bundle' => 'image',
-      'field_media_image' => [
-        'target_id' => $file->id(),
-        'alt' => 'Not random alt text...',
-      ],
-    ]);
-    $media->save();
-    $this->markEntityForCleanup($media);
-
-    $node = $this->createNode([
-      'type' => 'blog',
-      'body' => [
-        'summary' => 'In which I summarize my blog post.',
-        'value' => $random->paragraphs(1),
-      ],
-      'field_image' => $media,
-      'moderation_state' => 'published',
-    ]);
-    $this->drupalGet($node->toUrl());
-    $assert_session->statusCodeEquals(200);
-    $this->assertMetaTag('description', 'In which I summarize my blog post.');
-    $this->assertMetaTag('image_src', $file_url, 'link');
-    $this->assertMetaTag('og:description', 'In which I summarize my blog post.');
-    $this->assertMetaTag('og:image', $file_url);
-    $this->assertMetaTag('og:image:alt', 'Not random alt text...');
-    $this->assertMetaTag('og:title', $node->getTitle());
-    $this->assertMetaTag('og:type', 'Blog post');
-
-    $node = $this->createNode([
-      'type' => 'event',
-      'body' => [
-        'summary' => 'This party is gonna rock.',
-        'value' => $random->paragraphs(1),
-      ],
-      'field_image' => $media,
-      'field_location' => [
-        'country_code' => 'US',
-        'administrative_area' => 'DC',
-        'locality' => 'Washington',
-        'postal_code' => 20560,
-        'address_line1' => '1000 Jefferson Dr SW',
-      ],
-      'moderation_state' => 'published',
-    ]);
-    $this->drupalGet($node->toUrl());
-    $assert_session->statusCodeEquals(200);
-    $this->assertMetaTag('description', 'This party is gonna rock.');
-    $this->assertMetaTag('image_src', $file_url, 'link');
-    $this->assertMetaTag('og:country_name', 'United States');
-    $this->assertMetaTag('og:description', 'This party is gonna rock.');
-    $this->assertMetaTag('og:image', $file_url);
-    $this->assertMetaTag('og:image:alt', 'Not random alt text...');
-    $this->assertMetaTag('og:locality', 'Washington');
-    $this->assertMetaTag('og:postal_code', '20560');
-    $this->assertMetaTag('og:region', 'DC');
-    $this->assertMetaTag('og:street_address', '1000 Jefferson Dr SW');
-    $this->assertMetaTag('og:title', $node->getTitle());
-    $this->assertMetaTag('og:type', 'Event');
-  }
-
-  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta', bool $exact_match = TRUE): void {
-    $name_attribute = match ($tag_name) {
-      'meta' => str_contains($name, ':') ? 'property' : 'name',
-      'link' => 'rel',
-    };
-
-    $actual_value = $this->assertSession()
-      ->elementExists('css', $tag_name . '[' . $name_attribute . '="' . $name . '"]')
-      ->getAttribute(match ($tag_name) {
-        'meta' => 'content',
-        'link' => 'href',
-      });
-    if ($exact_match) {
-      $this->assertSame($expected_value, $actual_value);
-    }
-    else {
-      $this->assertStringContainsString($expected_value, $actual_value);
-    }
+    $assert_session->elementAttributeContains('css', 'meta[name="Generator"]', 'content', 'Drupal');
   }
 
 }

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -35,7 +35,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       ],
       'moderation_state' => 'published',
     ]);
-    $this->drupalGet('/?q=node/' . $node->id());
+    $this->drupalGet('/index.php?q=node/' . $node->id());
     $this->assertSame(200, $this->getSession()->getStatusCode(), $this->getSession()->getPage()->getContent());
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -36,7 +36,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
     $this->drupalGet($node->toUrl());
-    $this->assertSame(200, $this->getSession()->getStatusCode(), $node->toUrl()->toString());
+    $this->assertSame(200, $this->getSession()->getStatusCode(), $this->buildUrl($node->toUrl(), ['absolute' => TRUE]));
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');
     $this->assertMetaTag('og:description', 'Not a random summary...');

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -35,8 +35,8 @@ class BasicExpectationsTest extends ExistingSiteBase {
       ],
       'moderation_state' => 'published',
     ]);
-    $this->drupalGet('/node/' . $node->id());
-    $this->assertMetaTag('Generator', 'Drupal', exact_match: FALSE);
+    $this->drupalGet($node->toUrl());
+    $this->assertSame(200, $this->getSession()->getStatusCode(), $this->getSession()->getPage()->getContent());
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');
     $this->assertMetaTag('og:description', 'Not a random summary...');

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -35,7 +35,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       ],
       'moderation_state' => 'published',
     ]);
-    $this->drupalGet($node->toUrl());
+    $this->drupalGet('/?q=node/' . $node->id());
     $this->assertSame(200, $this->getSession()->getStatusCode(), $this->getSession()->getPage()->getContent());
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\starshot\ExistingSite;
 
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
@@ -20,6 +23,112 @@ class BasicExpectationsTest extends ExistingSiteBase {
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
     $assert_session->elementAttributeContains('css', 'meta[name="Generator"]', 'content', 'Drupal');
+
+    $random = $this->getRandomGenerator();
+
+    // If we create a page, all the expected meta tags should be there.
+    $node = $this->createNode([
+      'type' => 'page',
+      'body' => [
+        'summary' => 'Not a random summary...',
+        'value' => $random->paragraphs(1),
+      ],
+      'moderation_state' => 'published',
+    ]);
+    $this->drupalGet($node->toUrl());
+    $assert_session->statusCodeEquals(200);
+    $this->assertMetaTag('description', 'Not a random summary...');
+    $this->assertMetaTag('og:description', 'Not a random summary...');
+    $this->assertMetaTag('og:title', $node->getTitle());
+    $this->assertMetaTag('og:type', 'Basic page');
+
+    // Blog posts and events expose their image URLs in their meta tags, so
+    // create an image media entity to test with.
+    $file_uri = uniqid('public://') . '.png';
+    $file_uri = $random->image($file_uri, '100x100', '200x200');
+    $this->assertFileExists($file_uri);
+    $file = File::create(['uri' => $file_uri]);
+    $file->save();
+    $this->markEntityForCleanup($file);
+    $file_url = $this->container->get(FileUrlGeneratorInterface::class)
+      ->generateAbsoluteString($file_uri);
+
+    $media = Media::create([
+      'name' => $random->word(16),
+      'bundle' => 'image',
+      'field_media_image' => [
+        'target_id' => $file->id(),
+        'alt' => 'Not random alt text...',
+      ],
+    ]);
+    $media->save();
+    $this->markEntityForCleanup($media);
+
+    $node = $this->createNode([
+      'type' => 'blog',
+      'body' => [
+        'summary' => 'In which I summarize my blog post.',
+        'value' => $random->paragraphs(1),
+      ],
+      'field_image' => $media,
+      'moderation_state' => 'published',
+    ]);
+    $this->drupalGet($node->toUrl());
+    $assert_session->statusCodeEquals(200);
+    $this->assertMetaTag('description', 'In which I summarize my blog post.');
+    $this->assertMetaTag('image_src', $file_url, 'link');
+    $this->assertMetaTag('og:description', 'In which I summarize my blog post.');
+    $this->assertMetaTag('og:image', $file_url);
+    $this->assertMetaTag('og:image:alt', 'Not random alt text...');
+    $this->assertMetaTag('og:title', $node->getTitle());
+    $this->assertMetaTag('og:type', 'Blog post');
+
+    $node = $this->createNode([
+      'type' => 'event',
+      'body' => [
+        'summary' => 'This party is gonna rock.',
+        'value' => $random->paragraphs(1),
+      ],
+      'field_image' => $media,
+      'field_location' => [
+        'country_code' => 'US',
+        'administrative_area' => 'DC',
+        'locality' => 'Washington',
+        'postal_code' => 20560,
+        'address_line1' => '1000 Jefferson Dr SW',
+      ],
+      'moderation_state' => 'published',
+    ]);
+    $this->drupalGet($node->toUrl());
+    $assert_session->statusCodeEquals(200);
+    $this->assertMetaTag('description', 'This party is gonna rock.');
+    $this->assertMetaTag('image_src', $file_url, 'link');
+    $this->assertMetaTag('og:country_name', 'United States');
+    $this->assertMetaTag('og:description', 'This party is gonna rock.');
+    $this->assertMetaTag('og:image', $file_url);
+    $this->assertMetaTag('og:image:alt', 'Not random alt text...');
+    $this->assertMetaTag('og:locality', 'Washington');
+    $this->assertMetaTag('og:postal_code', '20560');
+    $this->assertMetaTag('og:region', 'DC');
+    $this->assertMetaTag('og:street_address', '1000 Jefferson Dr SW');
+    $this->assertMetaTag('og:title', $node->getTitle());
+    $this->assertMetaTag('og:type', 'Event');
+  }
+
+  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta'): void {
+    $name_attribute = match ($tag_name) {
+      'meta' => str_contains($name, ':') ? 'property' : 'name',
+      'link' => 'rel',
+    };
+
+    $actual_value = $this->assertSession()
+      ->elementExists('css', $tag_name . '[' . $name_attribute . '="' . $name . '"]')
+      ->getAttribute(match ($tag_name) {
+        'meta' => 'content',
+        'link' => 'href',
+      });
+
+    $this->assertSame($expected_value, $actual_value);
   }
 
 }

--- a/tests/src/ExistingSite/BasicExpectationsTest.php
+++ b/tests/src/ExistingSite/BasicExpectationsTest.php
@@ -36,6 +36,7 @@ class BasicExpectationsTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
     $this->drupalGet($node->toUrl());
+    $this->assertSame(200, $this->getSession()->getStatusCode(), $node->toUrl()->toString());
     $assert_session->statusCodeEquals(200);
     $this->assertMetaTag('description', 'Not a random summary...');
     $this->assertMetaTag('og:description', 'Not a random summary...');

--- a/tests/src/ExistingSite/MetaTagsTest.php
+++ b/tests/src/ExistingSite/MetaTagsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\starshot\ExistingSite;
+
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * @group starshot
+ */
+class MetaTagsTest extends ExistingSiteBase {
+
+  /**
+   * @testWith ["page"]
+   *   ["blog"]
+   *   ["event", {"field_location": {"country_code": "US", "administrative_area": "DC", "locality": "Washington", "postal_code": 20560, "address_line1": "1000 Jefferson Dr SW"}}, {"og:country_name": "United States", "og:locality": "Washington", "og:region": "DC", "og:postal_code":"20560", "og:street_address": "1000 Jefferson Dr SW"}]
+   */
+  public function testMetaTags(string $content_type, array $values = [], array $additional_meta_tags = []): void {
+    $random = $this->getRandomGenerator();
+
+    // If we create a page, all the expected meta tags should be there.
+    $node = $this->createNode($values + [
+      'type' => $content_type,
+      'body' => [
+        'summary' => 'Not a random summary...',
+        'value' => $random->paragraphs(1),
+      ],
+      'moderation_state' => 'published',
+    ]);
+    $this->drupalGet($node->toUrl());
+    $assert_session = $this->assertSession();
+    $assert_session->statusCodeEquals(200);
+    $this->assertMetaTag('description', 'Not a random summary...');
+    $this->assertMetaTag('og:description', 'Not a random summary...');
+    $this->assertMetaTag('og:title', $node->getTitle());
+    $this->assertMetaTag('og:type', $node->type->entity->label());
+
+    if ($node->hasField('field_image')) {
+      $file_uri = uniqid('public://') . '.png';
+      $file_uri = $random->image($file_uri, '100x100', '200x200');
+      $this->assertFileExists($file_uri);
+      $file = File::create(['uri' => $file_uri]);
+      $file->save();
+      $this->markEntityForCleanup($file);
+      $file_url = $this->container->get(FileUrlGeneratorInterface::class)
+        ->generateAbsoluteString($file_uri);
+
+      $media = Media::create([
+        'name' => $random->word(16),
+        'bundle' => 'image',
+        'field_media_image' => [
+          'target_id' => $file->id(),
+          'alt' => 'Not random alt text...',
+        ],
+      ]);
+      $media->save();
+      $this->markEntityForCleanup($media);
+
+      $node->set('field_image', $media)->save();
+      $this->getSession()->reload();
+      $this->assertMetaTag('image_src', $file_url, 'link');
+      $this->assertMetaTag('og:image', $file_url);
+      $this->assertMetaTag('og:image:alt', 'Not random alt text...');
+    }
+
+    foreach ($additional_meta_tags as $name => $value) {
+      $this->assertMetaTag($name, $value);
+    }
+  }
+
+  private function assertMetaTag(string $name, string $expected_value, string $tag_name = 'meta', bool $exact_match = TRUE): void {
+    $name_attribute = match ($tag_name) {
+      'meta' => str_contains($name, ':') ? 'property' : 'name',
+      'link' => 'rel',
+    };
+
+    $actual_value = $this->assertSession()
+      ->elementExists('css', $tag_name . '[' . $name_attribute . '="' . $name . '"]')
+      ->getAttribute(match ($tag_name) { 'meta' => 'content', 'link' => 'href'});
+
+    if ($exact_match) {
+      $this->assertSame($expected_value, $actual_value);
+    }
+    else {
+      $this->assertStringContainsString($expected_value, $actual_value);
+    }
+  }
+
+}


### PR DESCRIPTION
We had some trouble with meta tags not appearing, so let's let our first real test coverage be proving that all content types actually have meta tags that show up.