### PR TITLE
Add `drupal:run-tests` Composer script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,4 +96,4 @@ jobs:
 
       - name: Test
         working-directory: /var/www
-        run: ./vendor/bin/phpunit --testdox
+        run: composer drupal:run-tests -- --testdox

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /composer.lock
 /patches.lock.json
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,9 @@
             "Composer\\Config::disableProcessTimeout",
             "@php -d max_execution_time=0 web/core/scripts/drupal quick-start"
         ],
+        "drupal:run-tests": [
+            "./vendor/bin/phpunit"
+        ],
         "post-create-project-cmd": [
             "@drupal:install",
             "test -n \"$CI\" || composer drupal:run-server"
@@ -146,7 +149,8 @@
         "drupal:install": "Installs Starshot.",
         "drupal:install-dev": "Installs Starshot, with additional modules and configuration tweaks for development.",
         "drupal:rebuild": "Rebuilds the codebase and reinstalls Starshot from scratch. Should only be used for internal development.",
-        "drupal:run-server": "Runs Starshot using the PHP webserver and opens it in the default browser."
+        "drupal:run-server": "Runs Starshot using the PHP webserver and opens it in the default browser.",
+        "drupal:run-tests": "Runs Starshot's automated test suite."
     },
     "scripts-aliases": {
         "drupal:install": [
@@ -156,6 +160,9 @@
         "drupal:run-server": [
             "rs",
             "serve"
+        ],
+        "drupal:run-tests": [
+            "test"
         ]
     }
 }


### PR DESCRIPTION
If we want to encourage contribution, we should make it as simple as possible. This provides a `composer drupal:run-tests` (`composer test`) script to run PHPUnit.