### PR TITLE
Add default `uri` option to `drush/drush.yml`

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,3 +1,9 @@
+# https://www.drush.org/latest/using-drush-configuration/
+# https://www.drush.org/latest/examples/example.drush.yml/
+
+options:
+  uri: 'http://localhost/'
+
 command:
   site:
     install:


### PR DESCRIPTION
A lot folks would doubtless be helped if Drush was pre-configured to use a URI of `http://localhost/` instead of `http://default/` .