### PR TITLE
Make it extremely easy to boot up Starshot with LANDO

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,24 +2,14 @@ name: starshot
 recipe: drupal10
 config:
   webroot: web
-services:
-  appserver:
-    overrides:
-      environment:
-        DRUSH_OPTIONS_URI: "https://starshot.lndo.site"
 tooling:
-  install:
+  drupal:install:
     service: appserver
-    cmd:
-      - composer drupal:install
-  login:
-    service: appserver
-    cmd:
-      - echo "🚀 Board the spaceship! Click on the link below to login 👇"
-      - |
-        echo "
-        # Tell Drush about your website.
-        options:
-          uri: 'https://starshot.lndo.site'
-        " > drush/drush.yml
-      - drush uli
+    cmd: |
+      composer install
+      composer drupal:install
+      echo ""
+      echo "🚀 Board the spaceship!"
+      echo "👇 Click on the link below to login 👇"
+      drush uli -l 'https://starshot.lndo.site'
+      echo ""

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,25 @@
+name: starshot
+recipe: drupal10
+config:
+  webroot: web
+services:
+  appserver:
+    overrides:
+      environment:
+        DRUSH_OPTIONS_URI: "https://starshot.lndo.site"
+tooling:
+  install:
+    service: appserver
+    cmd:
+      - composer drupal:install
+  login:
+    service: appserver
+    cmd:
+      - echo "🚀 Board the spaceship! Click on the link below to login 👇"
+      - |
+        echo "
+        # Tell Drush about your website.
+        options:
+          uri: 'https://starshot.lndo.site'
+        " > drush/drush.yml
+      - drush uli

--- a/.lando.yml
+++ b/.lando.yml
@@ -8,8 +8,6 @@ tooling:
     cmd: |
       composer install
       composer drupal:install
-      echo ""
-      echo "🚀 Board the spaceship!"
-      echo "👇 Click on the link below to login 👇"
+      echo "🚀 Welcome to Starshot! Click on the link below to log in.👇"      
       drush uli -l 'https://starshot.lndo.site'
       echo ""

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You'll need DDEV 1.23.0 or later. [See the documentation](https://ddev.readthedo
 If you use [Lando](https://lando.dev/), you can get Starshot up and running with this:
 ```
 git clone https://github.com/phenaproxima/starshot-prototype.git starshot
-cd starshot && lando start && lando install && lando login
+cd starshot && lando start && lando drupal:install
 ```
 
 ## Included modules and themes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ cd starshot && ddev install
 ```
 You'll need DDEV 1.23.0 or later. [See the documentation](https://ddev.readthedocs.io/en/stable/users/install/ddev-upgrade/) if you need to upgrade.
 
+If you use [Lando](https://lando.dev/), you can get Starshot up and running with this:
+```
+git clone https://github.com/phenaproxima/starshot-prototype.git starshot
+cd starshot && lando start && lando install && lando login
+```
+
 ## Included modules and themes
 * [Address](https://drupal.org/project/address)
 * [Antibot](https://drupal.org/project/antibot)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You'll need DDEV 1.23.0 or later. [See the documentation](https://ddev.readthedo
 If you use [Lando](https://lando.dev/), you can get Starshot up and running with this:
 ```
 git clone https://github.com/phenaproxima/starshot-prototype.git starshot
-cd starshot && lando start && lando drupal:install
+cd starshot
+lando start && lando drupal:install
 ```
 
 ## Included modules and themes

--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@ Starshot is Drupal 10, but supercharged with some of the best modules and themes
 
 [![button.png](.tugboat%2Fbutton.png)](https://main-fw6eaiqwuojqnlnerzwoc8rf2ca8t4qq.tugboatqa.com/)
 
-[You can learn more about Starshot on drupal.org.](https://drupal.org/starshot)
+[Learn more about Starshot on drupal.org.](https://drupal.org/starshot)
+
+<hr/>
+
+- [Drupal Starshot](#drupal-starshot)
+- [Installation](#installation)
+- [Whom this is for](#whom-this-is-for)
+- [What this gets you](#what-this-gets-you)
+- [How this is different from a distribution](#how-this-is-different-from-a-distribution)
+- [Included modules and themes](#included-modules-and-themes)
+- [How we choose which modules and themes to include](#how-we-choose-which-modules-and-themes-to-include)
+- [Known issues \& workarounds](#known-issues--workarounds)
+  - [Server timeout](#server-timeout)
+  - [Error: SQLSTATE\[HY000\]: General error: 11 database disk image is malformed](#error-sqlstatehy000-general-error-11-database-disk-image-is-malformed)
 
 ## Installation
 ```
@@ -28,6 +41,30 @@ git clone https://github.com/phenaproxima/starshot-prototype.git starshot
 cd starshot
 lando start && lando drupal:install
 ```
+
+## Whom this is for
+Anyone who wants to create a website with Drupal, but doesn't want to build it -- including the authoring experience -- from the ground up using the relatively bare-bones tools provided by Drupal core. You need extra modules to get the most out of Drupal, but it can be hard to know how to start.
+
+Starshot's purpose is to get you going with the most useful tools favored by the Drupal community, as quickly and easily as possible.
+
+## What this gets you
+* Useful content types, already set up for translation, meta tags, pretty URLs, moderation, and scheduling.
+* A standard set of media types, with some enhancements (setting an image's focal point, for example, or better linking to uploaded documents).
+* An amazingly full-featured platform for building web forms with anti-spam protection.
+* A much nicer administrative experience than you'd get with plain Drupal, based on the Gin theme, plus the Navigation and Coffee modules.
+* Basic niceties:
+  * An XML site map
+  * Better date and time fields
+  * The ability to set up redirects
+  * Better handling of files on disk
+  * The ability to clone content
+  * Comparing different versions of content
+* Some sample content, so you're not starting from nothing.
+
+## How this is different from a distribution
+Distributions are based on install profiles, and therefore have a lock-in effect. If you start a site on a distribution, you can't really stop using that distribution -- at least, not easily. Starshot uses recipes to give you a strong starting point, but there is no lock-in.
+
+We don't _quite_ support this yet, but you'll also be able to use Starshot's components on an _existing_ site too. That's the power of recipes!
 
 ## Included modules and themes
 * [Address](https://drupal.org/project/address)
@@ -54,30 +91,6 @@ lando start && lando drupal:install
 
 ...and, of course, [Drush](https://www.drush.org).
 
-## What this gets you
-* Useful content types, already set up for translation, meta tags, pretty URLs, moderation, and scheduling.
-* A standard set of media types, with some enhancements (setting an image's focal point, for example, or better linking to uploaded documents).
-* An amazingly full-featured platform for building web forms with anti-spam protection.
-* A much nicer administrative experience than you'd get with plain Drupal, based on the Gin theme, plus the Navigation and Coffee modules.
-* Basic niceties:
-  * An XML site map
-  * Better date and time fields
-  * The ability to set up redirects
-  * Better handling of files on disk
-  * The ability to clone content
-  * Comparing different versions of content
-* Some sample content, so you're not starting from nothing.
-
-## Who this is for
-Anyone who wants to create a website with Drupal, but doesn't want to build it -- including the authoring experience -- from the ground up using the relatively bare-bones tools provided by Drupal core. You need extra modules to get the most out of Drupal, but it can be hard to know how to start.
-
-Starshot's purpose is to get you going with the most useful tools favored by the Drupal community, as quickly and easily as possible.
-
-## How is this different from a distribution?
-Distributions are based on install profiles, and therefore have a lock-in effect. If you start a site on a distribution, you can't really stop using that distribution -- at least, not easily. Starshot uses recipes to give you a strong starting point, but there is no lock-in.
-
-We don't _quite_ support this yet, but you'll also be able to use Starshot's components on an _existing_ site too. That's the power of recipes!
-
 ## How we choose which modules and themes to include
 Right now it's pretty much "let's add whatever we think is useful for most people". [We're working on defining a policy and process for this.](https://github.com/phenaproxima/starshot-prototype/issues/11) If you have an idea for a module to include, by all means [open an issue](https://github.com/phenaproxima/starshot-prototype/issues/new/choose)!
 
@@ -95,3 +108,16 @@ If you encounter this, you can restart the server using the following command:
 ```
 composer drupal:run-server
 ```
+
+### Error: SQLSTATE[HY000]: General error: 11 database disk image is malformed
+If you're using **DDEV with Docker Desktop on a Mac**, you might see the following error:
+
+```
+SQLSTATE[HY000]: General error: 11 database disk image is malformed`
+```
+This error is caused by the way files are shared between your Mac and Docker, which is set to `VirtioFS`. To fix it, change the file sharing method to either `gRPC FUSE` or `osxfs (Legacy)`:
+
+- [Open the Docker Desktop settings](https://docs.docker.com/desktop/settings/mac/).
+- Look for the "General" tab, and find the option for file sharing implementation.
+- Choose either `gRPC FUSE` or `osxfs (Legacy)` from the available options.
+- Click on **Apply & Restart** Docker.


### PR DESCRIPTION
Following the example in #50 I added a `.lando.yml` file to help users who prefer this tool, making it ridiculously easy to set up Starshot with LANDO. 

This PR adds that to the README too:
```
lando start && lando install && lando login
```