### PR TITLE
Remove the `drush` config file.

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,5 +1,0 @@
-# https://www.drush.org/latest/using-drush-configuration/
-# https://www.drush.org/latest/examples/example.drush.yml/
-
-options:
-  uri: 'http://localhost/'


### PR DESCRIPTION
I feel we should remove the drush configuration file, as it is overwriting the `DRUSH_OPTIONS_URI` setting when running `ddev drush uli`. 

Which outputs: `http://localhost/user/reset/1/1715615952/V4pMvp5c1aWQEmBgFFGbdZHeQno1xkPWy_nU7n1FAzM/login`

Removing the Drush configuration file will ensure that the `DRUSH_OPTIONS_URI` value is used when running `drush uli`.

After removing: `https://starshot.ddev.site/user/reset/1/1715616070/dPXXBM1fnUh6Nr17Snep7G1SH1hgZViuWiEyPg3El0E/login`