### PR TITLE
Update registration to admin only

### DIFF
--- a/recipes/starshot/recipe.yml
+++ b/recipes/starshot/recipe.yml
@@ -131,5 +131,5 @@ config:
     user.settings:
       simple_config_update:
         verify_mail: true
-        register: visitors_admin_approval
+        register: admin_only
         cancel_method: user_cancel_block


### PR DESCRIPTION
I left the `verify_mail: true` setting even though it's not required, because it's a useful default if you do end up enabling registration. But I could see an argument for removing it.