### PR TITLE
DDEV: Make sites/default folder writable, to allow deleting starshot folder after ddev delete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,8 @@
             "Composer\\Config::disableProcessTimeout",
             "cd web && php -d memory_limit=512M core/scripts/drupal install ../recipes/starshot",
             "drush webform-libraries-download",
-            "drush state:set project_browser.allowed_recipes '[starshot_multilingual]' --input-format=yaml --yes"
+            "drush state:set project_browser.allowed_recipes '[starshot_multilingual]' --input-format=yaml --yes",
+            "cd web && chmod 755 sites/default"
         ],
         "drupal:install-dev": [
             "cd web/sites/default && chmod +w . && rm -rf settings.php files",


### PR DESCRIPTION
## Problem

I need to `chmod 755 web/sites/default` before being allowed to delete the Starshot project folder. This does not happen in standard DDEV/Drupal installations, because `web/sites/default` folder has `drwxr-xr-x` permissions, not `dr-xr-xr-x`.

Starshot
```
~/dev/starshot$ l web/sites/
dr-xr-xr-x 3 user user 4,0K 25 maj 11:39 default
```

Standard Drupal 10
```
$ l web/sites/
drwxr-xr-x 3 user user 4,0K 24 maj 09:48 default
```

## Reproduce

Try to clean up and delete the Starshot folder after `ddev delete`, but get an error:
```
$  rm starshot/ -rf
rm: cannot remove 'starshot/web/sites/default/default.settings.php': Permission denied
rm: cannot remove 'starshot/web/sites/default/default.services.yml': Permission denied
rm: cannot remove 'starshot/web/sites/default/settings.php': Permission denied
rm: cannot remove 'starshot/web/sites/default/files': Permission denied
```

## Solution

Perhaps we can add write permission to that folder as a final step of the `ddev composer drupal:install`, something like `cd web && chmod 755 sites/default`?

Discussed in #94.