### PR TITLE
Make it possible to install into a different, non-SQLite database

### DIFF
--- a/.ddev/commands/host/install
+++ b/.ddev/commands/host/install
@@ -4,4 +4,4 @@
 
 ddev start
 ddev composer drupal:install
-test -n "$CI" || open $DDEV_PRIMARY_URL
+test -n "$CI" || ddev launch

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,10 +8,8 @@ router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-omit_containers: [db]
 use_dns_when_possible: true
 composer_version: "2"
-disable_settings_management: true
 web_environment:
   - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
 nodejs_version: "16"

--- a/.ddev/mutagen/mutagen.yml
+++ b/.ddev/mutagen/mutagen.yml
@@ -1,0 +1,33 @@
+# Please do `ddev mutagen reset` after changing this file.
+# See DDEV Mutagen docs at
+# https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+# For detailed information about mutagen configuration options, see
+# https://mutagen.io/documentation/introduction/configuration
+sync:
+  defaults:
+    mode: "two-way-resolved"
+    stageMode: "neighboring"
+    ignore:
+      paths:
+        # The top-level .git directory is ignored because where possible it's
+        # mounted into the container with a traditional docker bind-mount
+        - "/.git"
+        - "/.tarballs"
+        - "/.ddev/db_snapshots"
+        - "/.ddev/.importdb*"
+        - ".DS_Store"
+        - ".idea"
+        - "/web/sites/default/files"
+        # Don't sync the project's Drush configuration; it's only relevant on the
+        # host machine.
+        - "/drush/drush.yml"
+
+        # You can also exclude other directories from mutagen-syncing
+        # For example /var/www/html/var does not need to sync in TYPO3
+        # so you can add:
+        # - "/var"
+        # vcs like .git can be ignored for safety, but then some
+        # composer operations may fail if they use dev versions/git.
+        # vcs: true
+    symlink:
+      mode: "posix-raw"

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
     "scripts": {
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",
-            "cd web && php -d memory_limit=512M core/scripts/drupal install starshot_installer",
+            "drush site:install starshot_installer --yes",
             "drush webform-libraries-download"
         ],
         "drupal:install-dev": [

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/type_tray": "^1.2",
         "drupal/uli_custom_workflow": "^1.0",
         "drupal/webform": "^6.2",
-        "drush/drush": "^12.5",
+        "drush/drush": "^13",
         "oomphinc/composer-installers-extender": "^2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
     "scripts": {
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",
-            "drush site:install starshot_installer --yes",
+            "drush site:install --yes",
             "drush webform-libraries-download"
         ],
         "drupal:install-dev": [

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,5 +1,13 @@
 # https://www.drush.org/latest/using-drush-configuration/
 # https://www.drush.org/latest/examples/example.drush.yml/
 
+# These configuration options are only relevant on the host machine (i.e., not
+# in a DDEV web container). For this reason, it's specifically excluded from
+# DDEV's web container (see `.ddev/mutagen/mutagen.yml`).
 options:
   uri: 'http://localhost/'
+command:
+  site:
+    install:
+      options:
+        db-url: 'sqlite://localhost/../db.sqlite'


### PR DESCRIPTION
This PR allows DDEV, if used, to manage the site settings and run the database container, so that Drupal installs into the database provided by DDEV, rather than forcing a SQLite database.

It preserves the existing behavior of `composer create-project`, installing into a SQLite database via Drush.