### PR TITLE
Give all component recipes their own composer.json files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,49 +13,77 @@
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         },
+        "starshot": {
+            "type": "path",
+            "url": "recipes/starshot"
+        },
+        "starshot_admin_theme": {
+            "type": "path",
+            "url": "recipes/starshot_admin_theme"
+        },
+        "starshot_audio_media_type": {
+            "type": "path",
+            "url": "recipes/starshot_audio_media_type"
+        },
+        "starshot_basic_html_editor": {
+            "type": "path",
+            "url": "recipes/starshot_basic_html_editor"
+        },
+        "starshot_blog": {
+            "type": "path",
+            "url": "recipes/starshot_blog"
+        },
+        "starshot_content_type_base": {
+            "type": "path",
+            "url": "recipes/starshot_content_type_base"
+        },
+        "starshot_document_media_type": {
+            "type": "path",
+            "url": "recipes/starshot_document_media_type"
+        },
+        "starshot_event_content_type": {
+            "type": "path",
+            "url": "recipes/starshot_event_content_type"
+        },
+        "starshot_forms": {
+            "type": "path",
+            "url": "recipes/starshot_forms"
+        },
+        "starshot_full_html_editor": {
+            "type": "path",
+            "url": "recipes/starshot_full_html_editor"
+        },
+        "starshot_image_media_type": {
+            "type": "path",
+            "url": "recipes/starshot_image_media_type"
+        },
         "starshot_installer": {
             "type": "path",
-            "url": "./installer"
+            "url": "installer"
+        },
+        "starshot_local_video_media_type": {
+            "type": "path",
+            "url": "recipes/starshot_local_video_media_type"
         },
         "starshot_multilingual": {
             "type": "path",
-            "url": "./recipes/starshot_multilingual"
+            "url": "recipes/starshot_multilingual"
+        },
+        "starshot_page_content_type": {
+            "type": "path",
+            "url": "recipes/starshot_page_content_type"
         }
     },
     "require": {
         "ext-pdo_sqlite": "*",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^2",
-        "drupal/address": "^2.0",
-        "drupal/antibot": "^2.0",
-        "drupal/automatic_updates": "^3.1.3",
-        "drupal/coffee": "^1.4",
         "drupal/core-composer-scaffold": "^10.3",
         "drupal/core-project-message": "^10.3",
         "drupal/core-recommended": "^10.3",
-        "drupal/diff": "^1.3",
-        "drupal/focal_point": "^2.0",
-        "drupal/geolocation": "^3.12",
-        "drupal/gin": "3.x-dev",
-        "drupal/gin_toolbar": "1.x-dev",
-        "drupal/honeypot": "^2.1",
-        "drupal/linkit": "6.1.x-dev",
-        "drupal/media_entity_download": "^2.2",
-        "drupal/media_file_delete": "^1.3",
-        "drupal/metatag": "^2.0",
-        "drupal/pathauto": "^1.12",
-        "drupal/project_browser": "^2",
-        "drupal/quick_node_clone": "^1.18",
-        "drupal/redirect": "^1.9",
-        "drupal/sam": "^1.2",
-        "drupal/scheduler": "^2.0.2",
-        "drupal/simple_sitemap": "^4.1",
-        "drupal/smart_date": "^4.0",
-        "drupal/starshot_installer": "dev-main",
-        "drupal/starshot_multilingual": "dev-main",
-        "drupal/type_tray": "^1.2",
-        "drupal/uli_custom_workflow": "^1.0",
-        "drupal/webform": "^6.2",
+        "drupal/starshot": "*",
+        "drupal/starshot_installer": "*",
+        "drupal/starshot_multilingual": "*",
         "drush/drush": "^13",
         "oomphinc/composer-installers-extender": "^2"
     },

--- a/installer/composer.json
+++ b/installer/composer.json
@@ -4,6 +4,8 @@
     "description": "Provides install-time tweaks for Starshot. Not to be used in production.",
     "version": "dev-main",
     "require": {
+        "drupal/automatic_updates": "^3.1.3",
+        "drupal/project_browser": "^2",
         "symfony/process": "^6.4 || ^7"
     }
 }

--- a/recipes/starshot/composer.json
+++ b/recipes/starshot/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "drupal/starshot",
+    "type": "drupal-recipe",
+    "description": "Sets up a site with useful features and sample content.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/metatag": "^2",
+        "drupal/redirect": "^1.9",
+        "drupal/starshot_admin_theme": "*",
+        "drupal/starshot_audio_media_type": "*",
+        "drupal/starshot_blog": "*",
+        "drupal/starshot_basic_html_editor": "*",
+        "drupal/starshot_document_media_type": "*",
+        "drupal/starshot_event_content_type": "*",
+        "drupal/starshot_forms": "*",
+        "drupal/starshot_full_html_editor": "*",
+        "drupal/starshot_image_media_type": "*",
+        "drupal/starshot_local_video_media_type": "*",
+        "drupal/starshot_page_content_type": "*",
+        "drupal/uli_custom_workflow": "^1"
+    }
+}

--- a/recipes/starshot_admin_theme/composer.json
+++ b/recipes/starshot_admin_theme/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "drupal/starshot_admin_theme",
+    "type": "drupal-recipe",
+    "description": "Sets up a nice administrative theme and navigation.",
+    "version": "dev-main",
+    "require": {
+        "drupal/coffee": "^1.4",
+        "drupal/core": "^10.3",
+        "drupal/gin": "3.x-dev",
+        "drupal/gin_toolbar": "1.x-dev"
+    }
+}

--- a/recipes/starshot_audio_media_type/composer.json
+++ b/recipes/starshot_audio_media_type/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drupal/starshot_audio_media_type",
+    "type": "drupal-recipe",
+    "description": "Adds a few enhancements to the audio file media type.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/media_entity_download": "^2.2",
+        "drupal/media_file_delete": "^1.3"
+    }
+}

--- a/recipes/starshot_basic_html_editor/composer.json
+++ b/recipes/starshot_basic_html_editor/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/starshot_basic_html_editor",
+    "type": "drupal-recipe",
+    "description": "Enhances the Basic HTML editor with better linking and media support.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/linkit": "6.1.x-dev"
+    }
+}

--- a/recipes/starshot_blog/composer.json
+++ b/recipes/starshot_blog/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drupal/starshot_blog",
+    "type": "drupal-recipe",
+    "description": "Sets up a basic blog, with tagging and commenting.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/starshot_content_type_base": "*",
+        "drupal/starshot_image_media_type": "*"
+    }
+}

--- a/recipes/starshot_content_type_base/composer.json
+++ b/recipes/starshot_content_type_base/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "drupal/starshot_content_type_base",
+    "type": "drupal-recipe",
+    "description": "Provides basic infrastructure for moderation, meta tags, cloning, and scheduled publishing of content.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/diff": "^1.3",
+        "drupal/metatag": "^2",
+        "drupal/pathauto": "^1.12",
+        "drupal/quick_node_clone": "^1.18",
+        "drupal/sam": "^1.2",
+        "drupal/scheduler": "^2.0.2",
+        "drupal/simple_sitemap": "^4.1",
+        "drupal/type_tray": "^1.2"
+    }
+}

--- a/recipes/starshot_document_media_type/composer.json
+++ b/recipes/starshot_document_media_type/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drupal/starshot_document_media_type",
+    "type": "drupal-recipe",
+    "description": "Adds a few enhancements to the document media type.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/media_entity_download": "^2.2",
+        "drupal/media_file_delete": "^1.3"
+    }
+}

--- a/recipes/starshot_event_content_type/composer.json
+++ b/recipes/starshot_event_content_type/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "drupal/starshot_event_content_type",
+    "type": "drupal-recipe",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/address": "^2",
+        "drupal/geolocation": "^3.12",
+        "drupal/smart_date": "^4",
+        "drupal/starshot_content_type_base": "*",
+        "drupal/starshot_image_media_type": "*"
+    }
+}

--- a/recipes/starshot_forms/composer.json
+++ b/recipes/starshot_forms/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "drupal/starshot_forms",
+    "type": "drupal-recipe",
+    "description": "Provides a simple contact form, and tools for building more complex forms.",
+    "version": "dev-main",
+    "require": {
+        "drupal/antibot": "^2",
+        "drupal/core": "^10.3",
+        "drupal/honeypot": "^2.1",
+        "drupal/webform": "^6.2"
+    }
+}

--- a/recipes/starshot_full_html_editor/composer.json
+++ b/recipes/starshot_full_html_editor/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/starshot_full_html_editor",
+    "type": "drupal-recipe",
+    "description": "Enhances the Full HTML editor with better linking and media support.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/linkit": "6.1.x-dev"
+    }
+}

--- a/recipes/starshot_image_media_type/composer.json
+++ b/recipes/starshot_image_media_type/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drupal/starshot_image_media_type",
+    "type": "drupal-recipe",
+    "description": "Adds focal point-based cropping to the image media type.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/focal_point": "^2",
+        "drupal/media_file_delete": "^1.3"
+    }
+}

--- a/recipes/starshot_local_video_media_type/composer.json
+++ b/recipes/starshot_local_video_media_type/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drupal/starshot_local_video_media_type",
+    "type": "drupal-recipe",
+    "description": "Adds a few enhancements to the video file media type.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/media_entity_download": "^2.2",
+        "drupal/media_file_delete": "^1.3"
+    }
+}

--- a/recipes/starshot_page_content_type/composer.json
+++ b/recipes/starshot_page_content_type/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/starshot_page_content_type",
+    "type": "drupal-recipe",
+    "description": "Provides a basic Page content type with pretty URLs, moderation, scheduling, translation, and meta tags.",
+    "version": "dev-main",
+    "require": {
+        "drupal/core": "^10.3",
+        "drupal/starshot_content_type_base": "*"
+    }
+}


### PR DESCRIPTION
This is mostly just to provide an example of how recipes should be distributed in the wild, but if any of these get split out into the final Starshot product, it'll still be helpful.