### PR TITLE
Make Composer resolve dependencies from the PHP 8.1 platform

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 type: drupal
 ddev_version_constraint: '>= 1.23.0'
 docroot: web
-php_version: "8.3"
+php_version: "8.1"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,10 @@
             "oomphinc/composer-installers-extender": true
         },
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "8.1"
+        }
     },
     "extra": {
         "drupal-scaffold": {
@@ -181,6 +184,9 @@
         ],
         "drupal:run-tests": [
             "./vendor/bin/phpunit"
+        ],
+        "post-create-project-cmd": [
+            "@composer config --unset platform.php"
         ],
         "quick-start": [
             "@drupal:install",


### PR DESCRIPTION
Since we now always install dependencies via `composer create-project`, it is possible for DDEV and the host machine to have dependency conflicts due to different PHP platform versions.

To get around this, it's best for us to explicitly tell Composer which PHP version it should consider when resolving dependencies. Let's make that PHP 8.1, which is the minimum version required by Drupal 10.