### PR TITLE
Create a Composer script to change the document root

### DIFF
--- a/.ddev/commands/host/web-root
+++ b/.ddev/commands/host/web-root
@@ -3,4 +3,9 @@
 ## Description: Changes the document root of the project.
 
 ddev config --docroot=$1
+if [ $DDEV_PROJECT_STATUS == "stopped" ]; then
+  _STOP="1"
+  ddev start
+fi
 ddev composer web-root $1
+test -z "$_STOP" || ddev stop

--- a/.ddev/commands/host/web-root
+++ b/.ddev/commands/host/web-root
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+## Description: Changes the document root of the project.
+
+ddev config --docroot=$1
+ddev composer web-root $1

--- a/composer.json
+++ b/composer.json
@@ -271,7 +271,8 @@
         "drupal:rebuild": "Rebuilds the codebase and reinstalls Starshot from scratch. Should only be used for internal development.",
         "drupal:run-server": "Runs Starshot using the PHP webserver and opens it in the default browser.",
         "drupal:run-tests": "Runs Starshot's automated test suite.",
-        "quick-start": "Installs Starshot and opens it in a browser."
+        "quick-start": "Installs Starshot and opens it in a browser.",
+        "web-root": "Changes the configured web root in composer.json."
     },
     "scripts-aliases": {
         "drupal:install": [

--- a/composer.json
+++ b/composer.json
@@ -202,6 +202,9 @@
         }
     },
     "scripts": {
+        "web-root": [
+            "@putenv WEB_ROOT=web"
+        ],
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",
             "\\Drupal\\starshot_installer\\ScriptHandler::configureDrush",
@@ -209,7 +212,8 @@
             "drush webform-libraries-download"
         ],
         "drupal:install-dev": [
-            "cd web/sites/default && chmod +w . && rm -rf settings.php files",
+            "@web-root",
+            "cd $WEB_ROOT/sites/default && chmod +w . && rm -rf settings.php files",
             "@drupal:install",
             "drush config:set --yes system.logging error_level verbose",
             "drush install --yes default_content",
@@ -217,17 +221,19 @@
             "drush user:unblock editor"
         ],
         "drupal:rebuild": [
-            "sudo rm -rf vendor web composer.lock patches.lock.json | true",
-            "git checkout web/.gitkeep",
+            "@web-root",
+            "sudo rm -rf vendor $WEB_ROOT composer.lock patches.lock.json | true",
+            "git checkout $DOC_ROOT/.gitkeep",
             "@composer install",
             "@drupal:install"
         ],
         "drupal:run-server": [
             "Composer\\Config::disableProcessTimeout",
-            "@php -d max_execution_time=0 web/core/scripts/drupal quick-start"
+            "@web-root",
+            "@php -d max_execution_time=0 $WEB_ROOT/core/scripts/drupal quick-start"
         ],
         "drupal:run-tests": [
-            "./vendor/bin/phpunit"
+            "phpunit"
         ],
         "quick-start": [
             "@drupal:install",

--- a/composer.json
+++ b/composer.json
@@ -168,20 +168,45 @@
             }
         },
         "installer-paths": {
-            "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
-            "web/modules/contrib/{$name}": ["type:drupal-module"],
-            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
-            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
-            "web/profiles/custom/{$name}": ["type:drupal-custom-profile"],
-            "web/recipes/{$name}": ["type:drupal-recipe"],
-            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
+            "web/core": [
+                "type:drupal-core"
+            ],
+            "web/libraries/{$name}": [
+                "type:drupal-library"
+            ],
+            "web/modules/contrib/{$name}": [
+                "type:drupal-module"
+            ],
+            "web/profiles/contrib/{$name}": [
+                "type:drupal-profile"
+            ],
+            "web/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "drush/Commands/contrib/{$name}": [
+                "type:drupal-drush"
+            ],
+            "web/modules/custom/{$name}": [
+                "type:drupal-custom-module"
+            ],
+            "web/profiles/custom/{$name}": [
+                "type:drupal-custom-profile"
+            ],
+            "web/recipes/{$name}": [
+                "type:drupal-recipe"
+            ],
+            "web/themes/custom/{$name}": [
+                "type:drupal-custom-theme"
+            ]
         },
-        "installer-types": ["drupal-recipe"],
+        "installer-types": [
+            "drupal-recipe"
+        ],
         "drupal-core-project-message": {
-            "include-keys": ["homepage", "support"],
+            "include-keys": [
+                "homepage",
+                "support"
+            ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                 </>",
                 "<bg=blue;fg=white>  Congratulations, you’ve installed Starshot!    </>",
@@ -203,7 +228,8 @@
     },
     "scripts": {
         "web-root": [
-            "\\Drupal\\starshot_installer\\ScriptHandler::webRoot"
+            "\\Drupal\\starshot_installer\\ScriptHandler::webRoot",
+            "test -z \"$PREVIOUS_WEB_ROOT\" || sudo rm -rf $PREVIOUS_WEB_ROOT | true"
         ],
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",
@@ -223,7 +249,7 @@
         "drupal:rebuild": [
             "@web-root",
             "sudo rm -rf vendor $WEB_ROOT composer.lock patches.lock.json | true",
-            "git checkout $DOC_ROOT/.gitkeep",
+            "git checkout $WEB_ROOT/.gitkeep",
             "@composer install",
             "@drupal:install"
         ],

--- a/composer.json
+++ b/composer.json
@@ -228,8 +228,7 @@
     },
     "scripts": {
         "web-root": [
-            "\\Drupal\\starshot_installer\\ScriptHandler::webRoot",
-            "test -z \"$PREVIOUS_WEB_ROOT\" || sudo rm -rf $PREVIOUS_WEB_ROOT | true"
+            "\\Drupal\\starshot_installer\\ScriptHandler::webRoot"
         ],
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.json
+++ b/composer.json
@@ -203,7 +203,7 @@
     },
     "scripts": {
         "web-root": [
-            "@putenv WEB_ROOT=web"
+            "\\Drupal\\starshot_installer\\ScriptHandler::webRoot"
         ],
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.json
+++ b/composer.json
@@ -164,38 +164,38 @@
     "extra": {
         "drupal-scaffold": {
             "locations": {
-                "web-root": "web/"
+                "web-root": "www/"
             }
         },
         "installer-paths": {
-            "web/core": [
+            "www/core": [
                 "type:drupal-core"
             ],
-            "web/libraries/{$name}": [
+            "www/libraries/{$name}": [
                 "type:drupal-library"
             ],
-            "web/modules/contrib/{$name}": [
+            "www/modules/contrib/{$name}": [
                 "type:drupal-module"
             ],
-            "web/profiles/contrib/{$name}": [
+            "www/profiles/contrib/{$name}": [
                 "type:drupal-profile"
             ],
-            "web/themes/contrib/{$name}": [
+            "www/themes/contrib/{$name}": [
                 "type:drupal-theme"
             ],
             "drush/Commands/contrib/{$name}": [
                 "type:drupal-drush"
             ],
-            "web/modules/custom/{$name}": [
+            "www/modules/custom/{$name}": [
                 "type:drupal-custom-module"
             ],
-            "web/profiles/custom/{$name}": [
+            "www/profiles/custom/{$name}": [
                 "type:drupal-custom-profile"
             ],
-            "web/recipes/{$name}": [
+            "www/recipes/{$name}": [
                 "type:drupal-recipe"
             ],
-            "web/themes/custom/{$name}": [
+            "www/themes/custom/{$name}": [
                 "type:drupal-custom-theme"
             ]
         },

--- a/composer.json
+++ b/composer.json
@@ -164,38 +164,38 @@
     "extra": {
         "drupal-scaffold": {
             "locations": {
-                "web-root": "www/"
+                "web-root": "web/"
             }
         },
         "installer-paths": {
-            "www/core": [
+            "web/core": [
                 "type:drupal-core"
             ],
-            "www/libraries/{$name}": [
+            "web/libraries/{$name}": [
                 "type:drupal-library"
             ],
-            "www/modules/contrib/{$name}": [
+            "web/modules/contrib/{$name}": [
                 "type:drupal-module"
             ],
-            "www/profiles/contrib/{$name}": [
+            "web/profiles/contrib/{$name}": [
                 "type:drupal-profile"
             ],
-            "www/themes/contrib/{$name}": [
+            "web/themes/contrib/{$name}": [
                 "type:drupal-theme"
             ],
             "drush/Commands/contrib/{$name}": [
                 "type:drupal-drush"
             ],
-            "www/modules/custom/{$name}": [
+            "web/modules/custom/{$name}": [
                 "type:drupal-custom-module"
             ],
-            "www/profiles/custom/{$name}": [
+            "web/profiles/custom/{$name}": [
                 "type:drupal-custom-profile"
             ],
-            "www/recipes/{$name}": [
+            "web/recipes/{$name}": [
                 "type:drupal-recipe"
             ],
-            "www/themes/custom/{$name}": [
+            "web/themes/custom/{$name}": [
                 "type:drupal-custom-theme"
             ]
         },

--- a/installer/src/ScriptHandler.php
+++ b/installer/src/ScriptHandler.php
@@ -27,7 +27,7 @@ final class ScriptHandler {
     // If a new web root was passed, update `composer.json`.
     $arguments = $event->getArguments();
     if ($arguments) {
-      $old_root = rtrim($old_root, '/');
+      assert(str_ends_with($old_root, '/'));
       $new_root = rtrim($arguments[0], '/');
 
       $file = new JsonFile('composer.json');
@@ -35,8 +35,11 @@ final class ScriptHandler {
 
       $data['extra']['drupal-scaffold']['locations']['web-root'] = "$new_root/";
 
-      $installer_paths = array_keys($extra['installer-paths']);
-      $installer_paths = preg_replace("|^$old_root/|", "$new_root/", $installer_paths);
+      $installer_paths = preg_replace(
+        "|^$old_root|",
+        $data['extra']['drupal-scaffold']['locations']['web-root'],
+        array_keys($extra['installer-paths']),
+      );
       $data['extra']['installer-paths'] = array_combine($installer_paths, $extra['installer-paths']);
 
       $file->write($data);

--- a/installer/src/ScriptHandler.php
+++ b/installer/src/ScriptHandler.php
@@ -28,6 +28,7 @@ final class ScriptHandler {
     $arguments = $event->getArguments();
     if ($arguments) {
       assert(str_ends_with($old_root, '/'));
+      Platform::putEnv('PREVIOUS_WEB_ROOT', $old_root);
 
       $file = new JsonFile('composer.json');
       $data = $file->read();

--- a/installer/src/ScriptHandler.php
+++ b/installer/src/ScriptHandler.php
@@ -30,10 +30,6 @@ final class ScriptHandler {
       $old_root = rtrim($old_root, '/');
       $new_root = rtrim($arguments[0], '/');
 
-      if ($old_root !== $new_root) {
-        Platform::putEnv('PREVIOUS_WEB_ROOT', $old_root);
-      }
-
       $file = new JsonFile('composer.json');
       $data = $file->read();
 

--- a/installer/src/ScriptHandler.php
+++ b/installer/src/ScriptHandler.php
@@ -27,17 +27,20 @@ final class ScriptHandler {
     // If a new web root was passed, update `composer.json`.
     $arguments = $event->getArguments();
     if ($arguments) {
-      assert(str_ends_with($old_root, '/'));
-      Platform::putEnv('PREVIOUS_WEB_ROOT', $old_root);
+      $old_root = rtrim($old_root, '/');
+      $new_root = rtrim($arguments[0], '/');
+
+      if ($old_root !== $new_root) {
+        Platform::putEnv('PREVIOUS_WEB_ROOT', $old_root);
+      }
 
       $file = new JsonFile('composer.json');
       $data = $file->read();
 
-      $new_root = rtrim($arguments[0], '/');
       $data['extra']['drupal-scaffold']['locations']['web-root'] = "$new_root/";
 
       $installer_paths = array_keys($extra['installer-paths']);
-      $installer_paths = preg_replace("|^$old_root|", "$new_root/", $installer_paths);
+      $installer_paths = preg_replace("|^$old_root/|", "$new_root/", $installer_paths);
       $data['extra']['installer-paths'] = array_combine($installer_paths, $extra['installer-paths']);
 
       $file->write($data);


### PR DESCRIPTION
Partially fixes #47 by adding a `composer web-root` script which changes the web root.

This only rewrites `composer.json` in all the necessary places. It doesn't actually move any installed files, because that would either blow away files that aren't managed by Composer (site files, settings, possibly custom code), or break Drupal outright.

Because of that, this script is basically useless once the project has been set up (i.e., once dependencies are installed). So if you want to have a web root besides `web`, you either need to call `composer create-project --no-install` or run `ddev web-root` **before** doing `ddev quick-start`.