### PR TITLE
Fix install errors when passing database URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,16 +202,16 @@
         "drupal:install": [
             "Composer\\Config::disableProcessTimeout",
             "\\Drupal\\starshot_installer\\ScriptHandler::configureDrush",
-            "drush site:install --yes --account-pass admin --config drush-install.yml && rm -f drush-install.yml",
-            "drush webform-libraries-download"
+            "drush site:install --yes --account-pass admin --config drush-install.yml && rm -f drush-install.yml #",
+            "drush webform-libraries-download #"
         ],
         "drupal:install-dev": [
-            "cd web/sites/default && chmod +w . && rm -rf settings.php files",
+            "cd web/sites/default && chmod +w . && rm -rf settings.php files #",
             "@drupal:install",
-            "drush config:set --yes system.logging error_level verbose",
-            "drush install --yes default_content",
-            "drush user:password editor editor",
-            "drush user:unblock editor"
+            "drush config:set --yes system.logging error_level verbose #",
+            "drush install --yes default_content #",
+            "drush user:password editor editor #",
+            "drush user:unblock editor #"
         ],
         "drupal:rebuild": [
             "sudo rm -rf vendor web composer.lock patches.lock.json | true",


### PR DESCRIPTION
Composer passes the same arguments to each script listed for an event. When passing a database URL to the install script for ScriptHandler::configureDrush, scripts that cannot handle the argument fail. The fix is to add a hash so those scripts ignore the argument.