### PR TITLE
Remove router_http_port from project .ddev/config.yaml

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -2,8 +2,6 @@ type: drupal
 docroot: web
 php_version: "8.3"
 webserver_type: nginx-fpm
-router_http_port: "80"
-router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []


### PR DESCRIPTION
Normally `router_http_port` and `router_https_port` should not be set in the project; they should be set globally. Having them here would override what might be set globally.