### PR TITLE
docs: remove README section about database disk image malformed, fixes #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,5 @@ If you encounter this, you can restart the server using the following command:
 composer drupal:run-server
 ```
 
-### Error: SQLSTATE[HY000]: General error: 11 database disk image is malformed
-If you're using **DDEV with Docker Desktop on a Mac**, you might see the following error:
-```
-SQLSTATE[HY000]: General error: 11 database disk image is malformed`
-```
-This is caused by the way files are shared between your Mac and Docker, which is set to `VirtioFS`. To fix it, change the file sharing method to either `gRPC FUSE` or `osxfs (Legacy)`:
-
-- [Open the Docker Desktop settings](https://docs.docker.com/desktop/settings/mac/).
-- Look for the "General" tab, and find the option for file sharing implementation.
-- Choose either `gRPC FUSE` or `osxfs (Legacy)` from the available options.
-- Click on **Apply & Restart** Docker.
-
 ### Using Project Browser with DDEV
 If you're using DDEV, prefix the terminal commands suggested by Project Browser with `ddev exec`.


### PR DESCRIPTION
* #137 

Remove the scary warning and don't have people do weird things with their Docker Desktop mounting strategy. 