### PR TITLE
Remove DRUSH_OPTIONS_URI as unnecessary (DDEV provides it already)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,8 +12,7 @@ working_dir:
     web: /var/www/html/web
 use_dns_when_possible: true
 composer_version: "2"
-web_environment:
-    - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
+web_environment: []
 nodejs_version: "16"
 corepack_enable: false
 ddev_version_constraint: '>= 1.23.0'


### PR DESCRIPTION
I happened to note that this has the unnecessary 
```
web_environment:
    - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
```

DDEV already provides DRUSH_OPTIONS_URL for all `drupal*` project types. 

This PR removes it. It's not doing any harm, but not doing any good either.