### PR TITLE
Fixing recipe installation with drush.

### DIFF
--- a/.ddev/commands/host/recipe-start
+++ b/.ddev/commands/host/recipe-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: Installs Starshot and opens it in a browser.
+
+ddev start
+ddev composer install
+ddev composer drupal:install-recipe
+test -n "$CI" || ddev launch

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.phpunit.result.cache
 /composer.lock
 /patches.lock.json
+/recipes/notify_new_comments
 /vendor
 /web

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "drupal/core-recommended": "^10.3",
         "drupal/starshot": "*",
         "drupal/starshot_installer": "*",
-        "drush/drush": "^12.5"
+        "drush/drush": "13.x-dev"
     },
     "require-dev": {
         "drupal/core-dev": "^10.3",
@@ -174,7 +174,7 @@
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
             "web/modules/custom/{$name}": ["type:drupal-custom-module"],
             "web/profiles/custom/{$name}": ["type:drupal-custom-profile"],
-            "web/recipes/{$name}": ["type:drupal-recipe"],
+            "recipes/{$name}": ["type:drupal-recipe"],
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
         "drupal-core-project-message": {
@@ -206,6 +206,12 @@
             "rm -f drush-install.yml",
             "drush webform-libraries-download"
         ],
+        "drupal:install-recipe": [
+            "Composer\\Config::disableProcessTimeout",
+            "\\Drupal\\starshot_installer\\ScriptHandler::configureDrush",
+            "drush site:install --yes ../recipes/starshot --account-pass admin --site-name=Starshot",
+            "drush webform-libraries-download"
+        ],
         "drupal:install-dev": [
             "cd web/sites/default && chmod +w . && rm -rf settings.php files",
             "@drupal:install",
@@ -234,6 +240,7 @@
     },
     "scripts-descriptions": {
         "drupal:install": "Installs Starshot.",
+        "drupal:install-recipe": "Installs Starshot, using the recipes.",
         "drupal:install-dev": "Installs Starshot, with additional modules and configuration tweaks for development.",
         "drupal:rebuild": "Rebuilds the codebase and reinstalls Starshot from scratch. Should only be used for internal development.",
         "drupal:run-server": "Runs Starshot using the PHP webserver and opens it in the default browser.",

--- a/recipes/starshot/recipe.yml
+++ b/recipes/starshot/recipe.yml
@@ -42,6 +42,8 @@ install:
   - datetime
   - menu_ui
   - options
+  - project_browser
+  - redirect
   - shortcut
   - toolbar
   - field_ui


### PR DESCRIPTION
### Problem/Motivation

I am trying to create a new recipe for inclusion into the Starshot project.

While I recognise there is not a supported installation process that uses drush site:install and recipes, I am also aware that some work has been done to allow drush to use recipes and that work has been done in the Starshot ecosphere.

I have had `drush site:install --yes ../recipes/starshot ` working in the past.

The changes required in the recipe have not been kept in sync with some of the recent changes to the project and as such the drush si not longer works. It complains about there being config for project_browser and redirect, but these modules are not installed. The recipe also adds the notify_new_comments recipe, but the composer file adds new recipes in the web directory rather than the repo root as the site:install drush command expects. This leads to the notify_new_comments recipe not being found during the drush si process.

### Proposed resolution
This PR adds the dependency back in for project_browser and redirect. (although I would also consider removing the config changes requested by the recipe for these modules if they are not to be included at all)
This PR also changes the installer-paths entry for drupal-recipes so that new recipes are added to the recipes folder rather than creating a new web/recipes folder as it currently does.
This PR finally updates drush to a version that supports recipe installation.

As an addition, I have also added a ddev and composer command to install the site using recipes (I would be happy to remove this, as it is not a fix of the bugs mention above). This is a nice to have for my workflow and may be useful for others developing recipes for starshot.

### Remaining tasks

Agree on the approach and remove or amend the code as requested,

[Edit from the original subpar PR description]
drush cannot install starshot using recipes due to missing dependencies.