### PR TITLE
Use recipes' ability to borrow values from existing config to set up the Nominatim geocoder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,6 +194,7 @@
         "patches": {
             "drupal/core": {
                 "#3444246: Create a config action to set the status of the entity": "./patches/core/recipes-103.patch",
+                "#3303126: Allow recipes to reuse existing config values": "./patches/core/recipes-150.patch",
                 "Add config actions to make a bundle of an entity type translatable": "./patches/core/make-translatable-action.patch"
             }
         }

--- a/installer/starshot_installer.profile
+++ b/installer/starshot_installer.profile
@@ -2,13 +2,12 @@
 
 declare(strict_types=1);
 
-use Drupal\Component\Plugin\ConfigurableInterface;
 use Drupal\Core\Batch\BatchBuilder;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Recipe\InputCollector;
 use Drupal\Core\Recipe\Recipe;
 use Drupal\Core\Recipe\RecipeRunner;
-use Drupal\geocoder\Entity\GeocoderProvider;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
@@ -19,8 +18,6 @@ function starshot_installer_install_tasks(): array {
     'starshot_installer_apply_recipes' => [
       'type' => 'batch',
       'display_name' => t('Apply recipes'),
-    ],
-    'starshot_installer_configure_geocoder' => [
     ],
     'starshot_installer_uninstall_myself' => [
       // As a final task, this profile should uninstall itself.
@@ -46,7 +43,7 @@ function starshot_installer_form_install_settings_form_alter(array &$form): void
  * Implements hook_form_alter() for install_configure_form.
  */
 function starshot_installer_form_install_configure_form_alter(array &$form): void {
-  ['composer' => $composer, 'rsync' => $rsync] = \Drupal::configFactory()
+  ['composer' => $composer, 'rsync' => $rsync] = Drupal::configFactory()
     ->get('package_manager.settings')
     ->get('executables');
 
@@ -84,7 +81,7 @@ function _starshot_installer_install_configure_form_submit(array &$form, FormSta
   $rsync = $form_state->getValue('rsync');
 
   if ($composer && $rsync) {
-    \Drupal::configFactory()
+    Drupal::configFactory()
       ->getEditable('package_manager.settings')
       ->set('executables', [
         'composer' => $composer,
@@ -92,7 +89,7 @@ function _starshot_installer_install_configure_form_submit(array &$form, FormSta
       ])
       ->save();
 
-    \Drupal::configFactory()
+    Drupal::configFactory()
       ->getEditable('project_browser.admin_settings')
       ->set('allow_ui_install', TRUE)
       ->save();
@@ -109,7 +106,8 @@ function starshot_installer_apply_recipes(): array {
   $batch = new BatchBuilder();
   $batch->setTitle(t('Applying recipes'));
 
-  $recipe = Recipe::createFromDirectory(\Drupal::root() . '/recipes/starshot');
+  $recipe = Recipe::createFromDirectory(Drupal::root() . '/recipes/starshot');
+  Drupal::classResolver(InputCollector::class)->prepare($recipe);
 
   foreach (RecipeRunner::toBatchOperations($recipe) as [$callback, $arguments]) {
     $batch->addOperation($callback, $arguments);
@@ -117,25 +115,11 @@ function starshot_installer_apply_recipes(): array {
   return $batch->toArray();
 }
 
-function starshot_installer_configure_geocoder(): void {
-  /** @var \Drupal\geocoder\GeocoderProviderInterface $provider */
-  $provider = GeocoderProvider::load('nominatim');
-  $plugin = $provider->getPlugin();
-  if ($plugin instanceof ConfigurableInterface) {
-    $uuid = \Drupal::config('system.site')->get('uuid');
-    $configuration = $plugin->getConfiguration();
-    $configuration['userAgent'] = "Drupal $uuid";
-    $configuration['referer'] = "http://drupal-$uuid.local";
-    $plugin->setConfiguration($configuration);
-  }
-  $provider->save();
-}
-
 /**
  * Uninstalls this install profile, as a final step.
  */
 function starshot_installer_uninstall_myself(): void {
-  \Drupal::service(ModuleInstallerInterface::class)->uninstall([
+  Drupal::service(ModuleInstallerInterface::class)->uninstall([
     'starshot_installer',
   ]);
 }

--- a/patches/core/recipes-150.patch
+++ b/patches/core/recipes-150.patch
@@ -1,0 +1,331 @@
+diff --git a/core/lib/Drupal/Core/Recipe/InputCollector.php b/core/lib/Drupal/Core/Recipe/InputCollector.php
+new file mode 100644
+index 0000000000000000000000000000000000000000..4913ea603efd589d1fdcc67e59aa5b856516a1a5
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/InputCollector.php
+@@ -0,0 +1,67 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\ConfigFactoryInterface;
++use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class InputCollector implements ContainerInjectionInterface {
++
++  private function __construct(
++    private readonly ConfigFactoryInterface $configFactory,
++  ) {}
++
++  public static function create(ContainerInterface $container): self {
++    return new self(
++      $container->get(ConfigFactoryInterface::class),
++    );
++  }
++
++  public function prepare(Recipe $recipe): void {
++    static $processed = [];
++
++    if (in_array($recipe->path, $processed, TRUE)) {
++      return;
++    }
++
++    foreach ($recipe->recipes->recipes as $dependency) {
++      $this->prepare($dependency);
++    }
++
++    $values = [];
++    /** @var array{from: string, source?: string} $definition */
++    foreach ($recipe->inputDefinitions as $key => $definition) {
++      // Add more ways of collecting values here, as needed. We use a match
++      // expression because value collection is not extensible.
++      if ($definition['from'] === 'config') {
++        assert(array_key_exists('source', $definition));
++        $values[$key] = $this->getFromConfig($definition);
++      }
++    }
++    $recipe->setInputValues($values);
++    $processed[] = $recipe->path;
++  }
++
++  /**
++   * Fetches a value from config.
++   *
++   * @param array{source: string} $definition
++   *   The input definition. Must have a `source` element, which is a string
++   *   in the form `CONFIG_NAME:KEY`.
++   *
++   * @return mixed
++   *   A value from config.
++   */
++  private function getFromConfig(array $definition): mixed {
++    [$name, $key] = explode(':', $definition['source'], 2);
++    return $this->configFactory->get($name)->get($key);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/Recipe.php b/core/lib/Drupal/Core/Recipe/Recipe.php
+index 0312de9337010aa33917948c19737b5249595c41..716ff244905ec01454b7d28fe5e738bcd6a326d3 100644
+--- a/core/lib/Drupal/Core/Recipe/Recipe.php
++++ b/core/lib/Drupal/Core/Recipe/Recipe.php
+@@ -33,6 +33,41 @@ final class Recipe {
+
+   const COMPOSER_PROJECT_TYPE = 'drupal-recipe';
+
++  /**
++   * @var array<string, mixed>|null
++   */
++  private ?array $inputValues = NULL;
++
++  /**
++   * @var array<string, array<string, mixed>>
++   */
++  public readonly array $inputDefinitions;
++
++  /**
++   * @param string $name
++   *   The human-readable name of the recipe.
++   * @param string $description
++   *   A short description of the recipe.
++   * @param string $type
++   *   The recipe type.
++   * @param \Drupal\Core\Recipe\RecipeConfigurator $recipes
++   *   The recipe configurator, which lists the recipes that will be applied
++   *   before this one.
++   * @param \Drupal\Core\Recipe\InstallConfigurator $install
++   *   The install configurator, which lists the extensions this recipe will
++   *   install.
++   * @param \Drupal\Core\Recipe\ConfigConfigurator $config
++   *   The config configurator, which lists the config that this recipe will
++   *   install, and what config actions will be taken.
++   * @param \Drupal\Core\DefaultContent\Finder $content
++   *   The default content finder.
++   * @param string $path
++   *   The recipe's path.
++   * @param array<string, array<string, mixed>> $input_definitions
++   *   The recipe's input definitions, keyed by name. This is an array of arrays
++   *   where each sub-array has a `from` element, and the other elements vary
++   *   depending on what `from` is.
++   */
+   public function __construct(
+     public readonly string $name,
+     public readonly string $description,
+@@ -42,7 +77,10 @@ public function __construct(
+     public readonly ConfigConfigurator $config,
+     public readonly Finder $content,
+     public readonly string $path,
++    array $input_definitions,
+   ) {
++    assert(ksort($input_definitions));
++    $this->inputDefinitions = $input_definitions;
+   }
+
+   /**
+@@ -61,7 +99,7 @@ public static function createFromDirectory(string $path): static {
+     $install = new InstallConfigurator($recipe_data['install'], \Drupal::service('extension.list.module'), \Drupal::service('extension.list.theme'));
+     $config = new ConfigConfigurator($recipe_data['config'], $path, \Drupal::service('config.storage'));
+     $content = new Finder($path . '/content');
+-    return new static($recipe_data['name'], $recipe_data['description'], $recipe_data['type'], $recipes, $install, $config, $content, $path);
++    return new static($recipe_data['name'], $recipe_data['description'], $recipe_data['type'], $recipes, $install, $config, $content, $path, $recipe_data['input'] ?? []);
+   }
+
+   /**
+@@ -151,6 +189,17 @@ private static function parse(string $file): array {
+           ]),
+         ]),
+       ]),
++      'input' => new Optional([
++        new Type('array'),
++        new All([
++          new Collection([
++            'from' => new IdenticalTo('config'),
++            'source' => [
++              new Regex('/^(\w+\.)+\w+:\w+$/', message: 'This value must be in the format `CONFIG_NAME:KEY`.'),
++            ],
++          ]),
++        ]),
++      ]),
+       'config' => new Optional([
+         new Collection([
+           // Each entry in the `import` list can either be `*` (import all of
+@@ -285,4 +334,36 @@ private static function validateConfigActions(mixed $value, ExecutionContextInte
+     }
+   }
+
++  /**
++   * @param array<string, mixed> $values
++   *   The input values, keyed by name. The keys need to match the ones in the
++   *   recipe's input definitions, and all the defined inputs must have a
++   *   corresponding value in this array.
++   */
++  public function setInputValues(array $values): void {
++    if (is_array($this->inputValues)) {
++      throw new \LogicException("Recipe input values cannot be changed once they have been set.");
++    }
++    assert(ksort($values));
++    assert(array_keys($values) === array_keys($this->inputDefinitions));
++    $this->inputValues = $values;
++  }
++
++  /**
++   * @return array<string, mixed>
++   */
++  public function getInputValues(bool $prefixed = FALSE): array {
++    $values = [];
++    foreach ($this->recipes->recipes as $dependency) {
++      $values = array_merge($values, $dependency->getInputValues(TRUE));
++    }
++    foreach ($this->inputValues ?? [] as $key => $value) {
++      if ($prefixed) {
++        $key = basename($this->path) . '.' . $key;
++      }
++      $values[$key] = $value;
++    }
++    return $values;
++  }
++
+ }
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeCommand.php b/core/lib/Drupal/Core/Recipe/RecipeCommand.php
+index 3040e40960475a77d7e848350a26329ab72a5992..4bf0954f965e50025ce630e02e5bdbe53912d4e8 100644
+--- a/core/lib/Drupal/Core/Recipe/RecipeCommand.php
++++ b/core/lib/Drupal/Core/Recipe/RecipeCommand.php
+@@ -73,6 +73,7 @@ protected function execute(InputInterface $input, OutputInterface $output): int
+     /** @var \Drupal\Core\Config\Checkpoint\CheckpointStorageInterface $checkpoint_storage */
+     $checkpoint_storage = $container->get('config.storage.checkpoint');
+     $recipe = Recipe::createFromDirectory($recipe_path);
++    InputCollector::create($container)->prepare($recipe);
+     if ($checkpoint_storage instanceof LoggerAwareInterface) {
+       $logger = new ConsoleLogger($output, [
+         // The checkpoint storage logs a notice if it decides to not create a
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeRunner.php b/core/lib/Drupal/Core/Recipe/RecipeRunner.php
+index 626c203d0371f00142283f6d037039908fcc3855..000bfd0cd5c4c265830b7d0b424017fd33b7463d 100644
+--- a/core/lib/Drupal/Core/Recipe/RecipeRunner.php
++++ b/core/lib/Drupal/Core/Recipe/RecipeRunner.php
+@@ -30,11 +30,23 @@ final class RecipeRunner {
+   /**
+    * @param \Drupal\Core\Recipe\Recipe $recipe
+    *   The recipe to apply.
++   * @param bool $collect_input
++   *   (optional) Whether to collect input values (if the recipe, or any of its
++   *   dependencies, require any) before applying. Defaults to TRUE. Internal
++   *   use only.
+    */
+-  public static function processRecipe(Recipe $recipe): void {
+-    static::processRecipes($recipe->recipes);
++  public static function processRecipe(Recipe $recipe, bool $collect_input = TRUE): void {
++    // If we need to collect input for this recipe or any of its dependencies,
++    // do that now.
++    if ($collect_input) {
++      \Drupal::classResolver(InputCollector::class)->prepare($recipe);
++    }
++
++    foreach ($recipe->recipes->recipes as $dependency) {
++      static::processRecipe($dependency, FALSE);
++    }
+     static::processInstall($recipe->install, $recipe->config->getConfigStorage());
+-    static::processConfiguration($recipe->config);
++    static::processConfiguration($recipe);
+     static::processContent($recipe->content);
+     static::triggerEvent($recipe);
+   }
+@@ -54,18 +66,6 @@ public static function triggerEvent(Recipe $recipe, ?array &$context = NULL): vo
+     $context['results']['recipe'][] = $recipe->name;
+   }
+
+-  /**
+-   * Applies any recipes listed by the recipe.
+-   *
+-   * @param \Drupal\Core\Recipe\RecipeConfigurator $recipes
+-   *   The list of recipes to apply.
+-   */
+-  protected static function processRecipes(RecipeConfigurator $recipes): void {
+-    foreach ($recipes->recipes as $recipe) {
+-      static::processRecipe($recipe);
+-    }
+-  }
+-
+   /**
+    * Installs the extensions.
+    *
+@@ -89,10 +89,10 @@ protected static function processInstall(InstallConfigurator $install, StorageIn
+   /**
+    * Creates configuration and applies configuration actions.
+    *
+-   * @param \Drupal\Core\Recipe\ConfigConfigurator $config
+-   *   The config configurator from the recipe.
++   * @param \Drupal\Core\Recipe\Recipe $recipe
++   *   The recipe being applied.
+    */
+-  protected static function processConfiguration(ConfigConfigurator $config): void {
++  protected static function processConfiguration(Recipe $recipe): void {
+     $config_installer = new RecipeConfigInstaller(
+       \Drupal::service('config.factory'),
+       \Drupal::service('config.storage'),
+@@ -102,17 +102,23 @@ protected static function processConfiguration(ConfigConfigurator $config): void
+       NULL,
+       \Drupal::service('extension.path.resolver'));
+
++    $config = $recipe->config;
+     // Create configuration that is either supplied by the recipe or listed in
+     // the config.import section that does not exist.
+     $config_installer->installRecipeConfig($config);
+
+     if (!empty($config->config['actions'])) {
++      $values = $recipe->getInputValues();
++      // Prefix all the replacement strings with `%`.
++      $keys = array_map(fn ($k) => "%$k", array_keys($values));
++      $replace = array_combine($keys, $values);
++
+       // Process the actions.
+       /** @var \Drupal\Core\Config\Action\ConfigActionManager $config_action_manager */
+       $config_action_manager = \Drupal::service('plugin.manager.config_action');
+       foreach ($config->config['actions'] as $config_name => $actions) {
+         foreach ($actions as $action_id => $data) {
+-          $config_action_manager->applyAction($action_id, $config_name, $data);
++          $config_action_manager->applyAction($action_id, $config_name, static::searchAndReplace($data, $replace));
+         }
+       }
+     }
+@@ -297,7 +303,7 @@ public static function installTheme(string $theme, StorageInterface|Recipe $reci
+    *   The batch context if called by a batch.
+    */
+   public static function installConfig(Recipe $recipe, ?array &$context = NULL): void {
+-    static::processConfiguration($recipe->config);
++    static::processConfiguration($recipe);
+     $context['message'] = t('Installed configuration for %recipe recipe.', ['%recipe' => $recipe->name]);
+     $context['results']['config'][] = $recipe->name;
+   }
+@@ -316,4 +322,26 @@ public static function installContent(Recipe $recipe, ?array &$context = NULL):
+     $context['results']['content'][] = $recipe->name;
+   }
+
++  /**
++   * @param mixed $data
++   *   The data that will have placeholders replaced.
++   * @param array<string, mixed> $replace
++   *   An array whose keys are the placeholders to be replaced, and whose values
++   *   are the replacements.
++   *
++   * @return mixed
++   *   The passed data, with placeholders replaced.
++   */
++  private static function searchAndReplace(mixed $data, array $replace): mixed {
++    if (is_string($data)) {
++      $data = str_replace(array_keys($replace), $replace, $data);
++    }
++    elseif (is_array($data)) {
++      foreach ($data as $key => $value) {
++        $data[$key] = static::searchAndReplace($value, $replace);
++      }
++    }
++    return $data;
++  }
++
+ }

--- a/recipes/starshot_event_content_type/config/geocoder.geocoder_provider.nominatim.yml
+++ b/recipes/starshot_event_content_type/config/geocoder.geocoder_provider.nominatim.yml
@@ -11,6 +11,5 @@ configuration:
   geocoder:
     locale: ''
   rootUrl: 'https://nominatim.openstreetmap.org'
-  # @see starshot_installer_configure_geocoder()
   userAgent: ''
   referer: ''

--- a/recipes/starshot_event_content_type/recipe.yml
+++ b/recipes/starshot_event_content_type/recipe.yml
@@ -5,17 +5,27 @@ recipes:
   - starshot_image_media_type
 install:
   - address
+  - geocoder
   - geocoder_address
   - geocoder_geofield
   - layout_builder
   - leaflet_more_maps
   - smart_date
+input:
+  site_uuid:
+    from: config
+    source: 'system.site:uuid'
 config:
   import:
     filter:
       - filter.format.plain_text
     smart_date: '*'
   actions:
+    geocoder.geocoder_provider.nominatim:
+      # This is a hack; switch to a real config action as soon as reasonable.
+      simple_config_update:
+        configuration.userAgent: 'Drupal %site_uuid'
+        configuration.referer: 'http://drupal-%site_uuid.local'
     metatag.settings:
       simple_config_update:
         entity_type_groups.node.event:


### PR DESCRIPTION
Part of why Starshot needs an install profile is to run a function that configures the Nominatim geocoder with a user agent and referer.

Once https://www.drupal.org/project/distributions_recipes/issues/3303126 lands, recipes will have the ability to use existing config values as ephemeral tokens, thus obviating the need for that function. Why wait, though? We can patch core. I propose we do just that, with an abbreviated patch from that issue (we don't need the tests), and trim the install profile down a bit. This brings us a step closer to being able to install Starshot at the command line without using the profile at all.