### PR TITLE
Update ddev.yml to fail when quickstart fails

### DIFF
--- a/.ddev/commands/host/quick-start
+++ b/.ddev/commands/host/quick-start
@@ -2,6 +2,8 @@
 
 ## Description: Installs Starshot and opens it in a browser.
 
+set -e
+
 ddev start
 ddev composer install
 ddev composer drupal:install

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -31,6 +31,7 @@ jobs:
           sudo sh -c 'echo ""'
           sudo apt update && sudo apt install -y ddev
 
+      - name: Install Starshot
         run: |
           ddev quick-start
 

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -32,13 +32,7 @@ jobs:
           sudo apt update && sudo apt install -y ddev
 
       - name: Install Starshot
-        run: |
-          OUTPUT=$(ddev quick-start 2>&1)
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "returned with error code 1"; then
-            echo "Starshot installation failed"
-            exit 1
-          fi
+        run: ddev quick-start
 
       - name: Confirm that Starshot is running
         run: |

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -31,8 +31,8 @@ jobs:
           sudo sh -c 'echo ""'
           sudo apt update && sudo apt install -y ddev
 
-      - name: Install Starshot
-        run: ddev quick-start
+        run: |
+          ddev quick-start
 
       - name: Confirm that Starshot is running
         run: |

--- a/.github/workflows/ddev.yml
+++ b/.github/workflows/ddev.yml
@@ -33,7 +33,12 @@ jobs:
 
       - name: Install Starshot
         run: |
-          ddev quick-start
+          OUTPUT=$(ddev quick-start 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "returned with error code 1"; then
+            echo "Starshot installation failed"
+            exit 1
+          fi
 
       - name: Confirm that Starshot is running
         run: |


### PR DESCRIPTION
* ddev quick-start is set up to not fail when one of its component scripts, like drush site-install fails
* This change addresses this by forcing an error code on the quick-start script when of of its components fail

I'm not sure whether this is by design and I understand the main.yml script also checks the site-install process, I just thought it was weird this script will not fail when the installation process has errors. 