### PR TITLE
Patch Automatic Updates with #3463662

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -196,6 +196,9 @@
                 "#3444246: Create a config action to set the status of the entity": "./patches/core/recipes-103.patch",
                 "#3303126: Allow recipes to reuse existing config values": "./patches/core/recipes-150.patch",
                 "Add config actions to make a bundle of an entity type translatable": "./patches/core/make-translatable-action.patch"
+            },
+            "drupal/automatic_updates": {
+                "#3463662: When it is installed, Package Manager should try to detect the paths of Composer and rsync": "./patches/automatic_updates/automatic_updates-1085.patch"
             }
         }
     },


### PR DESCRIPTION
Part of the reason we need an install profile is to ensure Package Manager is configured as early as possible with the paths to Composer and rsync. It seems crazy to me that this is not part of Package Manager itself, and I've opened https://www.drupal.org/project/automatic_updates/issues/3463662 to fix that.

In the meantime, we should apply that patch, which would get us a step closer to allowing Starshot to be installed without the profile at all (at the command line, anyway -- the UI installer will still use the profile, since it would still require some profile-only superpowers, like automatic profile selection and redirecting to Project Browser as a final step).