### PR TITLE
Enable Gin's high contrast mode to improve accessibility

### DIFF
--- a/recipes/starshot_admin_theme/recipe.yml
+++ b/recipes/starshot_admin_theme/recipe.yml
@@ -14,8 +14,6 @@ config:
     gin.settings:
       simple_config_update:
         high_contrast_mode: true
-        accent_color: ''
-        focus_color: ''
     system.theme:
       simple_config_update:
         admin: gin

--- a/recipes/starshot_admin_theme/recipe.yml
+++ b/recipes/starshot_admin_theme/recipe.yml
@@ -11,6 +11,11 @@ config:
     gin: '*'
     navigation: '*'
   actions:
+    gin.settings:
+      simple_config_update:
+        high_contrast_mode: true
+        accent_color: ''
+        focus_color: ''
     system.theme:
       simple_config_update:
         admin: gin


### PR DESCRIPTION
### Problem/Motivation

The accessibility of the gin admin theme can be improved by enabling its high contrast option.

### Proposed resolution

Enable the high contrast mode.