### PR TITLE
Enabling Inline form errors module to improve form a11y.

### DIFF
--- a/recipes/starshot/recipe.yml
+++ b/recipes/starshot/recipe.yml
@@ -36,6 +36,7 @@ install:
   # The rest of these are in Standard.
   - help
   - history
+  - inline_form_errors
   - config
   - contextual
   - menu_link_content


### PR DESCRIPTION
### Problem/Motivation

The accessibility of Drupal forms can be improved by enabling the Inline form errors module.
https://www.drupal.org/docs/8/core/modules/inline-form-errors

### Proposed resolution

Install the core inline form errors module.