### PR TITLE
Move Simple Add More and Type Tray into the starshot_admin_theme recipe

### DIFF
--- a/recipes/starshot_admin_theme/composer.json
+++ b/recipes/starshot_admin_theme/composer.json
@@ -7,6 +7,8 @@
         "drupal/coffee": "^1.4",
         "drupal/core": ">=10.3",
         "drupal/gin": "^3-rc11",
-        "drupal/gin_toolbar": "^1-rc6"
+        "drupal/gin_toolbar": "^1-rc6",
+        "drupal/sam": "^1.2",
+        "drupal/type_tray": "^1.2"
     }
 }

--- a/recipes/starshot_admin_theme/recipe.yml
+++ b/recipes/starshot_admin_theme/recipe.yml
@@ -6,6 +6,8 @@ install:
   - gin
   - gin_toolbar
   - navigation
+  - sam
+  - type_tray
 config:
   import:
     gin: '*'

--- a/recipes/starshot_content_type_base/composer.json
+++ b/recipes/starshot_content_type_base/composer.json
@@ -9,9 +9,7 @@
         "drupal/metatag": "^2",
         "drupal/pathauto": "^1.12",
         "drupal/quick_node_clone": "^1.18",
-        "drupal/sam": "^1.2",
         "drupal/scheduler": "^2.0.2",
-        "drupal/simple_sitemap": "^4.1",
-        "drupal/type_tray": "^1.2"
+        "drupal/simple_sitemap": "^4.1"
     }
 }

--- a/recipes/starshot_content_type_base/recipe.yml
+++ b/recipes/starshot_content_type_base/recipe.yml
@@ -10,10 +10,8 @@ install:
   - node
   - pathauto
   - quick_node_clone
-  - sam
   - scheduler
   - simple_sitemap
-  - type_tray
   - views
 config:
   import:


### PR DESCRIPTION
I think these modules are distinct improvements the admin experience and not really part of the content types' data models or features. Therefore, let's move them to the starshot_admin_theme recipe.