### PR TITLE
Clean up the installer by wrapping existing install tasks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -204,6 +204,7 @@
                 "#3464550: Create config action which can create an entity for every bundle of another entity type": "./patches/core/8975.patch",
                 "#3303127: Determine which core config entity methods should be config actions": "./patches/core/7940.patch",
                 "Allow arbitrary callables to provide input to recipes": "./patches/core/recipe-callable-input.patch",
+                "Ensure core recipes that affect user roles also install the User module": "./patches/core/core-recipes-user-import.patch",
                 "#3416357: Convert QueueFactory to use a service locator": "./patches/core/3416357-10.3.x-only.patch"
             },
             "drupal/automatic_updates": {

--- a/patches/core/core-recipes-user-import.patch
+++ b/patches/core/core-recipes-user-import.patch
@@ -1,0 +1,60 @@
+diff --git a/core/recipes/comment_base/recipe.yml b/core/recipes/comment_base/recipe.yml
+index 0cf967155a..73acd8b891 100644
+--- a/core/recipes/comment_base/recipe.yml
++++ b/core/recipes/comment_base/recipe.yml
+@@ -4,6 +4,7 @@ type: 'Comment type'
+ install:
+   - comment
+   - node
++  - user
+   - views
+ config:
+   import:
+@@ -16,6 +17,9 @@ config:
+       - system.action.comment_unpublish_action
+       - views.view.comment
+       - views.view.comments_recent
++    user:
++      - user.role.anonymous
++      - user.role.authenticated
+   actions:
+     user.role.authenticated:
+       grantPermissions:
+diff --git a/core/recipes/content_search/recipe.yml b/core/recipes/content_search/recipe.yml
+index b9f60c59a7..e0e20c68cb 100644
+--- a/core/recipes/content_search/recipe.yml
++++ b/core/recipes/content_search/recipe.yml
+@@ -4,12 +4,16 @@ description: 'Adds a page that can search site content.'
+ install:
+   - node
+   - search
++  - user
+ config:
+   import:
+     node:
+       - core.entity_view_mode.node.search_index
+       - core.entity_view_mode.node.search_result
+       - search.page.node_search
++    user:
++      - user.role.anonymous
++      - user.role.authenticated
+   actions:
+     user.role.anonymous:
+       grantPermissions:
+diff --git a/core/recipes/restricted_html_format/recipe.yml b/core/recipes/restricted_html_format/recipe.yml
+index 8aec764918..89c4c8c5d9 100644
+--- a/core/recipes/restricted_html_format/recipe.yml
++++ b/core/recipes/restricted_html_format/recipe.yml
+@@ -3,9 +3,12 @@ description: 'Provides "Restricted HTML" text format.'
+ type: 'Text format'
+ install:
+   - filter
++  - user
+ config:
+   import:
+     filter: '*'
++    user:
++      - user.role.anonymous
+   actions:
+     user.role.anonymous:
+       grantPermission: 'use text format restricted_html'

--- a/recipes/starshot_anti_spam/recipe.yml
+++ b/recipes/starshot_anti_spam/recipe.yml
@@ -4,7 +4,10 @@ description: 'Sets up anti-spam and anti-abuse functionality.'
 install:
   - antibot
   - honeypot
+  - user
 config:
+  import:
+    user: '*'
   actions:
     honeypot.settings:
       simple_config_update:

--- a/recipes/starshot_basic_html_editor/recipe.yml
+++ b/recipes/starshot_basic_html_editor/recipe.yml
@@ -5,10 +5,12 @@ install:
   - ckeditor5
   - linkit
   - media_library
+  - user
 config:
   import:
     linkit:
       - image.style.linkit_result_thumbnail
+    user: '*'
   actions:
     user.role.authenticated:
       grantPermission: 'use text format basic_html'


### PR DESCRIPTION
This changes the installer in such a way that we don't need to add additional steps; we can just piggyback on existing installer tasks.