### PR TITLE
Add login_emailusername

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Starshot's purpose is to get you going with the most useful tools favored by the
   * The ability to clone content
   * Comparing different versions of content
   * Email notifications when a comment is posted
+  * Logging in with your email address instead of a username
 * Some sample content, so you're not starting from nothing.
 
 ## How this is different from a distribution
@@ -74,6 +75,7 @@ We don't _quite_ support this yet, but you'll also be able to use Starshot's com
 * [Honeypot](https://drupal.org/project/honeypot)
 * [Leaflet More Maps](https://drupal.org/project/leaflet_more_maps)
 * [Linkit](https://drupal.org/project/linkit)
+* [Login Email or Username](https://drupal.org/project/login_emailusername)
 * [Media Entity Download](https://drupal.org/project/media_entity_download)
 * [Media File Delete](https://drupal.org/project/media_file_delete)
 * [Metatag](https://drupal.org/project/metatag)

--- a/recipes/starshot/composer.json
+++ b/recipes/starshot/composer.json
@@ -7,6 +7,7 @@
         "drupal/core": ">=10.3",
         "drupal/easy_breadcrumb": "^2",
         "drupal/eca": "^2",
+        "drupal/login_emailusername": "^2.1",
         "drupal/metatag": "^2",
         "drupal/redirect": "^1.9",
         "drupal/starshot_admin_theme": "*",

--- a/recipes/starshot/recipe.yml
+++ b/recipes/starshot/recipe.yml
@@ -31,6 +31,7 @@ recipes:
 install:
   - easy_breadcrumb
   - eca_ui
+  - login_emailusername
   - metatag
   - menu_link_content
   - redirect


### PR DESCRIPTION
Logging in by username only is outmoded and inconvenient. Let's make it possible to login with your email address. I haven't personally used this module before but it has a solid install base and claims to be zero configuration.

I'll leave the final decision to commit to @pameeela or someone else who actually builds sites, but from a value perspective, in my personal opinion, this feels like the no-braineriest of no-brainers.